### PR TITLE
return None if species doesnt exist or if species name unavailable

### DIFF
--- a/analysis_driver/reader/demultiplexing_parsers.py
+++ b/analysis_driver/reader/demultiplexing_parsers.py
@@ -151,24 +151,14 @@ def parse_fastqscreen_file(filename, myFocalSpecies):
         return fastqscreen_result
     else:
         app_logger.warning('The focal species is not included in the contaminant database')
-        contaminantsUniquelyMapped['None'] = 100
-        fastqscreen_result = {ELEMENT_CONTAMINANT_UNIQUE_MAP:contaminantsUniquelyMapped,
-                                         ELEMENT_TOTAL_READS_MAPPED:100,
-                                         ELEMENT_PCNT_UNMAPPED_FOCAL:100,
-                                         ELEMENT_PCNT_UNMAPPED:100}
+        fastqscreen_result = None
         return fastqscreen_result
 
 def get_fastqscreen_results(filename, sample_id):
     myFocalSpecies = get_species_from_sample(sample_id)
     if myFocalSpecies is None:
         app_logger.warning('No species name available')
-        contaminantsUniquelyMapped = {}
-        contaminantsUniquelyMapped['None'] = 100
-        fastqscreen_result = {ELEMENT_CONTAMINANT_UNIQUE_MAP:contaminantsUniquelyMapped,
-                                         ELEMENT_TOTAL_READS_MAPPED:100,
-                                         ELEMENT_PCNT_UNMAPPED_FOCAL:100,
-                                         ELEMENT_PCNT_UNMAPPED:100}
-        return fastqscreen_result
+        return None
     else:
         fastqscreen_results = parse_fastqscreen_file(filename, myFocalSpecies)
         return fastqscreen_results

--- a/tests/test_reader/test_demultiplexing_parsers.py
+++ b/tests/test_reader/test_demultiplexing_parsers.py
@@ -26,14 +26,14 @@ class TestDemultiplexingStats(TestAnalysisDriver):
     def test_parse_fastqscreen_file2(self):
         testFile = os.path.join(self.assets_path, "test_sample_R1_screen.txt")
         result = parse_fastqscreen_file(testFile, 'Mellivora capensis')
-        assert result == {ELEMENT_PCNT_UNMAPPED: 100, ELEMENT_PCNT_UNMAPPED_FOCAL: 100, ELEMENT_TOTAL_READS_MAPPED: 100, ELEMENT_CONTAMINANT_UNIQUE_MAP: {'None': 100}}
+        assert result is None
 
     @patch('analysis_driver.reader.demultiplexing_parsers.get_species_from_sample', autospec=True)
     def test_get_fastqscreen_results1(self, mocked_species_sample):
         testFile = os.path.join(self.assets_path, "test_sample_R1_screen.txt")
         mocked_species_sample.return_value = None
         result = get_fastqscreen_results(testFile, 'testSampleID')
-        assert result == {ELEMENT_PCNT_UNMAPPED: 100, ELEMENT_PCNT_UNMAPPED_FOCAL: 100, ELEMENT_TOTAL_READS_MAPPED: 100, ELEMENT_CONTAMINANT_UNIQUE_MAP: {'None': 100}}
+        assert result is None
 
     @patch('analysis_driver.reader.demultiplexing_parsers.get_species_from_sample', autospec=True)
     def test_get_fastqscreen_results2(self, mocked_species_sample):


### PR DESCRIPTION
Previously returned '100' for all values, though this might be misleading in the future. Now no contamination information sent if species is unavailable.
