### PR TITLE
Pipeline stopping

### DIFF
--- a/analysis_driver/client.py
+++ b/analysis_driver/client.py
@@ -47,7 +47,7 @@ def main():
         for d in args.force:
             scanner.get_dataset(d).force()
         for d in args.stop:
-            pid = scanner.get_dataset(d).most_recent_proc.pid
+            pid = scanner.get_dataset(d).most_recent_proc.get('pid')
             if pid:
                 os.kill(pid, 15)
 
@@ -166,5 +166,6 @@ def _parse_args():
         default=[],
         help='mark a sample for processing, even if below the data threshold'
     )
+    p.add_argument('--stop', nargs='+', default=[], help='stop a currently processing run/sample')
 
     return p.parse_args()


### PR DESCRIPTION
The pipeline now reacts to `10` and `15` termination signals, and cleanly sends notifications and stops any running cluster jobs. Note that other signals are not caught.

A running pipeline can be sent a sigterm either by pid via `kill <signal>`, or by dataset name via `analysis_driver --stop <dataset_names>`.
