### PR TITLE
Ete catch unknown taxids

### DIFF
--- a/analysis_driver/quality_control/contamination_blast.py
+++ b/analysis_driver/quality_control/contamination_blast.py
@@ -6,8 +6,7 @@ from egcg_core import executor
 from .quality_control_base import QualityControl
 from analysis_driver.config import default as cfg
 from analysis_driver.exceptions import AnalysisDriverError
-from egcg_core.app_logging import logging_default as log_cfg
-app_logger = log_cfg.get_logger(__name__)
+
 
 class ContaminationBlast(QualityControl):
 
@@ -66,7 +65,7 @@ class ContaminationBlast(QualityControl):
                 rank = self.ncbi.get_rank(l)
             except ValueError:
                 rank = {0: 'rank unavailable'}
-                app_logger.warning('The taxid %s does not exist in the ETE TAXDB' % (taxon))
+                self.warning('The taxid %s does not exist in the ETE TAXDB' % (taxon))
             return rank
 
 

--- a/analysis_driver/quality_control/contamination_blast.py
+++ b/analysis_driver/quality_control/contamination_blast.py
@@ -59,8 +59,11 @@ class ContaminationBlast(QualityControl):
     def get_ranks(self, taxon):
         '''retrieve the rank of each of the taxa from that taxid's lineage'''
         if not taxon == 'N/A':
-            l = self.ncbi.get_lineage(int(taxon))
-            rank = self.ncbi.get_rank(l)
+            try:
+                l = self.ncbi.get_lineage(int(taxon))
+                rank = self.ncbi.get_rank(l)
+            except ValueError:
+                rank = 'unavailable'
             return rank
 
 

--- a/analysis_driver/quality_control/contamination_blast.py
+++ b/analysis_driver/quality_control/contamination_blast.py
@@ -6,6 +6,8 @@ from egcg_core import executor
 from .quality_control_base import QualityControl
 from analysis_driver.config import default as cfg
 from analysis_driver.exceptions import AnalysisDriverError
+from egcg_core.app_logging import logging_default as log_cfg
+app_logger = log_cfg.get_logger(__name__)
 
 class ContaminationBlast(QualityControl):
 
@@ -63,7 +65,8 @@ class ContaminationBlast(QualityControl):
                 l = self.ncbi.get_lineage(int(taxon))
                 rank = self.ncbi.get_rank(l)
             except ValueError:
-                rank = 'unavailable'
+                rank = {0: 'rank unavailable'}
+                app_logger.warning('The taxid %s does not exist in the ETE TAXDB' % (taxon))
             return rank
 
 

--- a/tests/test_quality_control/test_contamination_blast.py
+++ b/tests/test_quality_control/test_contamination_blast.py
@@ -71,6 +71,11 @@ class TestContaminationBlast(QCTester):
             ncbi.return_value.get_lineage.assert_called_once_with(9960)
             ncbi.return_value.get_rank.assert_called_once_with([9604, 33208, 89593])
 
+        with patch('analysis_driver.quality_control.ContaminationBlast.ncbi', new_callable=PropertyMock) as ncbi:
+            e = ValueError
+            ncbi().get_lineage.side_effect = e
+            assert self.contamination_blast.get_ranks('9960') == {0: 'rank unavailable'}
+
     @patch('analysis_driver.quality_control.ContaminationBlast.get_ranks')
     def test_get_all_taxa_identified1(self, mocked_rank):
         with patch('analysis_driver.quality_control.ContaminationBlast.ncbi', new_callable=PropertyMock) as ncbi:


### PR DESCRIPTION
When a taxid is not found in the ETE taxid db, make that rank 'Unavailable' rather than breaking