### PR TITLE
Driver proc refactor

### DIFF
--- a/analysis_driver/client.py
+++ b/analysis_driver/client.py
@@ -39,10 +39,7 @@ def main():
         for d in args.abort:
             scanner.get_dataset(d).abort()
         for d in args.skip:
-            dataset = scanner.get_dataset(d)
-            dataset.reset()
-            dataset.start()
-            dataset.succeed(quiet=True)
+            scanner.get_dataset(d).skip()
         for d in args.reset:
             scanner.get_dataset(d).reset()
         for d in args.force:

--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -275,8 +275,8 @@ class MostRecentProc:
 
     def update_entity(self, **kwargs):
         with self.lock:
-            if not self.entity:
-                self.initialise_entity()
+            if not self.entity:  # initialise self._entity with database content, or {} if none available
+                self.initialise_entity()  # if self._entity == {}, then initialise and push to database
 
             self.entity.update(kwargs)
             self.sync()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -315,15 +315,15 @@ class TestMostRecentProc(TestAnalysisDriver):
             )
 
         self.proc._entity = None
-        with patched_get([]):
-            y = self.proc.entity
-            assert y is None
-            mocked_get.assert_called_with(
-                'analysis_driver_procs',
-                where={'dataset_type': 'test', 'dataset_name': 'test'},
-                sort='-_created'
-            )
-            assert mocked_initialise.call_count == 1
+        mocked_get.return_value = []
+        y = self.proc.entity
+        assert y == {}
+        mocked_get.assert_called_with(
+            'analysis_driver_procs',
+            where={'dataset_type': 'test', 'dataset_name': 'test'},
+            sort='-_created'
+        )
+        assert mocked_initialise.call_count == 0
 
     @patched_post
     @patched_patch
@@ -335,7 +335,7 @@ class TestMostRecentProc(TestAnalysisDriver):
             'analysis_driver_procs',
             {'proc_id': 'test_test_now', 'dataset_type': 'test', 'dataset_name': 'test'}
         )
-        mocked_patch.assertcalled_with(
+        mocked_patch.assert_called_with(
             'tests',
             {'analysis_driver_procs': ['test_test_now']},
             id_field='test_id',


### PR DESCRIPTION
When running integration tests, I noticed that sample processing was failing. Rest communication was returning an `UNPROCESSABLE ENTITY`, with an error message of `{"proc_id": "value '<name>_<datetime>' is not unique"}`.

This turned out to be because there is a call stack of:
- dataset_scanner.scan_datasets
- dataset.status
- dataset.most_recent_proc.get
- most_recent_proc.entity
- most_recent_proc.initialise_entity

This means that a database entry is created if absent, even if the most_recent_proc is only being 'pinged' for a status. This means:

- scanner scans for datasets, calling `most_recent_proc.initialise_entity`
- one dataset is processed
- `dataset.start` is called, which calls `most_recent_proc.initialise_entity` again
- because the test environment is much faster, this all happens within one second, causing the same proc_id to be pushed to the database twice, which fails

Another side-effect of this is that samples in the reporting app always have at least two analysis_driver_procs, one of which is empty.

This can be fixed by moving the `initialise_entity` call to `most_recent_proc.update_entity`, when the entity is being written to, rather than just read.
