### PR TITLE
Allow any focal species

### DIFF
--- a/analysis_driver/reader/demultiplexing_parsers.py
+++ b/analysis_driver/reader/demultiplexing_parsers.py
@@ -186,24 +186,26 @@ def parse_fastqscreen_file(filename, focal_species):
             species_name = r.split('\t')[0].replace('_', ' ')
             species.append(species_name)
 
-    if focal_species in species:
-        for r in results:
-            species_name = r.split('\t')[0].replace('_', ' ')
-            results = r.split('\t')[1:12]
-
-            nb_uniquely_mapped = int(r.split('\t')[4]) + int(r.split('\t')[6])
-            uniquely_mapped[species_name] = nb_uniquely_mapped
-            if species_name == focal_species:
-                focal_species_pc_unmapped = float(results[2])
-        uniquely_mapped = {k: v for k, v in uniquely_mapped.items() if v != 0}
-        return {
-            ELEMENT_CONTAMINANT_UNIQUE_MAP: uniquely_mapped,
-            ELEMENT_TOTAL_READS_MAPPED: total_reads_mapped,
-            ELEMENT_PCNT_UNMAPPED_FOCAL: focal_species_pc_unmapped,
-            ELEMENT_PCNT_UNMAPPED: hit_no_genomes
-        }
-    else:
+    if not focal_species in species:
         app_logger.warning('The focal species is not included in the contaminant database')
+
+    for r in results:
+        species_name = r.split('\t')[0].replace('_', ' ')
+        results = r.split('\t')[1:12]
+
+        nb_uniquely_mapped = int(r.split('\t')[4]) + int(r.split('\t')[6])
+        uniquely_mapped[species_name] = nb_uniquely_mapped
+        if species_name == focal_species:
+            focal_species_pc_unmapped = float(results[2])
+
+    uniquely_mapped = {k: v for k, v in uniquely_mapped.items() if v != 0}
+
+    return {
+        ELEMENT_CONTAMINANT_UNIQUE_MAP: uniquely_mapped,
+        ELEMENT_TOTAL_READS_MAPPED: total_reads_mapped,
+        ELEMENT_PCNT_UNMAPPED_FOCAL: focal_species_pc_unmapped,
+        ELEMENT_PCNT_UNMAPPED: hit_no_genomes
+    }
 
 
 def read_histogram_file(input_file):

--- a/analysis_driver/reader/demultiplexing_parsers.py
+++ b/analysis_driver/reader/demultiplexing_parsers.py
@@ -175,7 +175,8 @@ def parse_fastqscreen_file(filename, focal_species):
         return None
 
     uniquely_mapped = {}
-    focal_species_pc_unmapped = ''
+    # set to 100% as default in case no focal species is available
+    focal_species_pc_unmapped = float(100)
     species = []
     with open(filename) as open_file:
         lines = open_file.readlines()

--- a/tests/test_reader/test_demultiplexing_parsers.py
+++ b/tests/test_reader/test_demultiplexing_parsers.py
@@ -63,7 +63,16 @@ class TestDemultiplexingStats(TestAnalysisDriver):
     def test_parse_fastqscreen_file2(self):
         screen_file = os.path.join(self.assets_path, 'test_sample_R1_screen.txt')
         result = dm.parse_fastqscreen_file(screen_file, 'Mellivora capensis')
-        assert result is None
+        assert result == {'contaminant_unique_mapped':
+                              {'Bos taurus': 1,
+                               'Felis catus': 4,
+                               'Gallus gallus': 1,
+                               'Homo sapiens': 74144,
+                               'Ovis aries': 2,
+                               'Mus musculus': 4},
+                          'percent_unmapped': 1.06,
+                          'percent_unmapped_focal': '',
+                          'total_reads_mapped': 100000}
 
     def test_calculate_mean(self):
         hist_file = os.path.join(self.assets_path, 'test_sample.depth')

--- a/tests/test_reader/test_demultiplexing_parsers.py
+++ b/tests/test_reader/test_demultiplexing_parsers.py
@@ -71,7 +71,7 @@ class TestDemultiplexingStats(TestAnalysisDriver):
                                'Ovis aries': 2,
                                'Mus musculus': 4},
                           'percent_unmapped': 1.06,
-                          'percent_unmapped_focal': '',
+                          'percent_unmapped_focal': 100.0,
                           'total_reads_mapped': 100000}
 
     def test_calculate_mean(self):


### PR DESCRIPTION
Do not assume focal species will be given, rather give a warning but return empty string for 'focal_species_unique_mapped' if  no fastqscreen species matches focal species name

Fixes #232