### PR TITLE
Detect bad tiles interop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+#Command ran before the install
+before_install:
+  - "pip install pip --upgrade"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 script: py.test tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 script: py.test tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "3.4"
-  - "3.5"
   - "3.6"
 #Command ran before the install
 before_install:

--- a/analysis_driver/quality_control/detect_bad_tiles.py
+++ b/analysis_driver/quality_control/detect_bad_tiles.py
@@ -1,0 +1,79 @@
+from collections import defaultdict
+from itertools import islice
+
+from analysis_driver.reader.run_info import Reads
+from .quality_control_base import QualityControl
+from interop.py_interop_run_metrics import run_metrics as RunMetrics
+
+
+
+class BadTileDetector(QualityControl):
+    def __init__(self, job_dir, dataset):
+        super().__init__(dataset, job_dir)
+        self.run_dir = dataset.input_dir
+        self.tile_ids = dataset.run_info.tiles
+        self.ncycles = sum(Reads.num_cycles(r) for r in dataset.run_info.reads.reads)
+        self.window_size = 50
+        self.quality_threshold = 20
+
+        self.read_interop_metrics()
+
+    def read_interop_metrics(self):
+        run_metrics = RunMetrics()
+        run_metrics.read(self.run_dir)
+        q_metric_set = run_metrics.q_metric_set()
+        metrics = q_metric_set.metrics()
+
+        self.all_lanes = {}
+        for lane in range(1, 9):
+            self.all_lanes[lane] = {}
+
+        for i in range(metrics.size()):
+            tile_dict = self.all_lanes[metrics[i].lane()]
+            if metrics[i].tile() not in tile_dict:
+                tile_dict[metrics[i].tile()] = [None] * self.ncycles
+            tile_dict[metrics[i].tile()][metrics[i].cycle()-1] = metrics[i].qscore_hist()
+
+    @staticmethod
+    def windows(l, window_size):
+        it = iter(l)
+        result = tuple(islice(it, window_size))
+        if len(result) == window_size:
+            yield result
+        for elem in it:
+            result = result[1:] + (elem,)
+            yield result
+
+    @staticmethod
+    def average_from_list_hist(q_hist_list):
+        q_hist_list = [hist for hist in q_hist_list if hist]
+        if len(q_hist_list) == 0:
+            return None
+        q8, q12, q22, q27, q32, q37, q41 = q_hist_list[0]
+        for q_hist in q_hist_list[1:]:
+            tq8, tq12, tq22, tq27, tq32, tq37, tq41 = q_hist
+            q8 += tq8
+            q12 += tq12
+            q22 += tq22
+            q27 += tq27
+            q32 += tq32
+            q37 += tq37
+            q41 += tq41
+        d = q8 * 8 + q12 * 12 + q22 * 22 + q27 * 27 + q32 * 32 + q37 * 37 + q41 * 41
+        return d/sum((q8, q12, q22, q27, q32, q37, q41))
+
+    def is_bad_sliding_window(self, lane, tile):
+        cycles_list = self.all_lanes[lane][tile]
+        for window in self.windows(cycles_list, self.window_size):
+            avg = self.average_from_list_hist(window)
+            if avg is not None and avg < self.quality_threshold:
+                return True
+        return False
+
+    def detect_bad_tile(self):
+        bad_tiles_per_lanes = defaultdict(list)
+        for lane in self.all_lanes:
+            for tile in self.all_lanes[lane]:
+                if self.is_bad_sliding_window(lane, tile):
+                    bad_tiles_per_lanes[lane].append(tile)
+        return bad_tiles_per_lanes

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ ete3==3.0.0b35
 illuminate==0.6.4
 pip>=9.0.1
 scipy
-numpy
+numpy>=1.12.1
 -f https://github.com/Illumina/interop/releases/tag/v1.0.23
 interop

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ ete3==3.0.0b35
 illuminate==0.6.4
 pip>=9.0.1
 scipy
+numpy
 -f https://github.com/Illumina/interop/releases/tag/v1.0.23
 interop

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ EGCG-Core==0.6.8
 luigi==2.5.0
 ete3==3.0.0b35
 illuminate==0.6.4
+pip>=9.0.1
+scipy
+-f https://github.com/Illumina/interop/releases/tag/v1.0.23
+interop

--- a/tests/test_quality_control/test_detect_bad_tiles.py
+++ b/tests/test_quality_control/test_detect_bad_tiles.py
@@ -20,6 +20,10 @@ class TestBadTileDetector(TestAnalysisDriver):
         l = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
         expected_lists = [('a', 'b', 'c'), ('b', 'c', 'd'), ('c', 'd', 'e'), ('d', 'e', 'f'), ('e', 'f', 'g')]
         assert list(self.detector.windows(l, window_size=3)) == expected_lists
+        l = ['a', 'b', 'c']
+        assert list(self.detector.windows(l, window_size=4)) == []
+
+
 
     def test_average_from_list_hist(self):
         list_hist = [

--- a/tests/test_quality_control/test_detect_bad_tiles.py
+++ b/tests/test_quality_control/test_detect_bad_tiles.py
@@ -1,0 +1,58 @@
+import os
+from unittest.mock import Mock, patch, call
+
+from analysis_driver.quality_control.detect_bad_tiles import BadTileDetector
+from tests.test_analysisdriver import TestAnalysisDriver
+from egcg_core import executor
+from analysis_driver.quality_control import BCLValidator
+
+
+class TestBadTileDetector(TestAnalysisDriver):
+    def setUp(self):
+        run_info = Mock(
+            tiles=('1_1101', '2_1101', '1_1102', '2_1102'),
+            reads=Mock(reads=[Mock(attrib={'NumCycles': '3'})])
+        )
+        self.job_dir = os.path.join(TestAnalysisDriver.assets_path, 'bcl_validation')
+        self.detector = BadTileDetector(self.job_dir, Mock(input_dir=self.job_dir, run_info=run_info))
+
+    def test_windows(self):
+        l = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+        expected_lists = [('a', 'b', 'c'), ('b', 'c', 'd'), ('c', 'd', 'e'), ('d', 'e', 'f'), ('e', 'f', 'g')]
+        assert list(self.detector.windows(l, window_size=3)) == expected_lists
+
+    def test_average_from_list_hist(self):
+        list_hist = [
+            (1, 2, 1, 5, 6, 9, 3),
+            (0, 1, 2, 4, 1, 4, 8),
+        ]
+        assert self.detector.average_from_list_hist(list_hist) == 32.1063829787234
+        list_hist = [(1, 1, 1, 1, 1, 1, 1)]
+        assert self.detector.average_from_list_hist(list_hist) == 25.571428571428573
+        list_hist = [(1, 1, 1, 1, 1, 1, 1), None]
+        assert self.detector.average_from_list_hist(list_hist) == 25.571428571428573
+        list_hist = [None, None]
+        assert self.detector.average_from_list_hist(list_hist) is None
+        list_hist = []
+        assert self.detector.average_from_list_hist(list_hist) is None
+
+    def test_is_bad_sliding_window(self):
+        list_q_hist1 = [
+            (0, 1, 1, 1, 1, 1, 10),
+            (0, 1, 1, 1, 1, 1, 10),
+            (0, 10, 1, 1, 1, 1, 1),
+            (0, 10, 1, 1, 1, 1, 1),
+            (0, 1, 1, 1, 1, 1, 10)
+        ]
+        list_q_hist2 = [
+            (0, 1, 1, 1, 1, 1, 10),
+            (0, 1, 1, 1, 1, 1, 10),
+            (0, 10, 1, 1, 1, 1, 1),
+            (0, 1, 1, 1, 1, 1, 10),
+            (0, 1, 1, 1, 1, 1, 10)
+        ]
+        self.detector.window_size = 2
+        self.detector.all_lanes = {1:{'1101': list_q_hist1, '1102': list_q_hist2}}
+        assert self.detector.is_bad_sliding_window(1, '1101')
+
+        assert not self.detector.is_bad_sliding_window(1, '1102')


### PR DESCRIPTION
This PR adds a new QC that can detect bad tile by parsing the interop files.
This is meant to be used in addition to tile filtering in fastq filterer
The interop package is tricky to install and has caused issue in travis.
On mac only python 3.6 is supported and on linux I've only manage to make it work on 3.4 and 3.6. 