### PR TITLE
Stage multiprocessing fixes

### DIFF
--- a/analysis_driver/client.py
+++ b/analysis_driver/client.py
@@ -120,12 +120,12 @@ def _process_dataset(d):
         stop_running_jobs()
         d.fail(sig)
         sys.exit(sig)
-    # SIGUSR1 is used by luigi to stop submitting new jobs.
+    # SIGUSR1 is used by Luigi to stop submitting new jobs.
     # make sure here that SIGUSR1 is caught even if luigi is not running.
     signal.signal(signal.SIGUSR1, _sigterm_handler)
-    # SIGUSR2 is used by analysis driver to know that another analysis driver process has asked it to be terminated.
+    # SIGUSR2 is used by Analysis Driver to know that another driver process has asked it to terminate.
     signal.signal(signal.SIGUSR2, _sigterm_handler)
-    # SIGTERM is used by analysis driver to know that a manual process has asked it to be terminated.
+    # SIGTERM is used by Analysis Driver to know that a manual process has asked it to be terminated.
     signal.signal(signal.SIGTERM, _sigterm_handler)
     exit_status = 9
     try:

--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -99,8 +99,7 @@ class Dataset(AppLogger):
         self._terminate(signal.SIGUSR2)
 
     def soft_terminate(self):
-        '''send SIGUSR1 to analysis driver and rely on luigi picking it up.
-        Luigi will stop submitting new job but finish the currently running jobs'''
+        """Send SIGUSR1 to analysis driver, causing Luigi to stop submitting any new jobs."""
         self._terminate(signal.SIGUSR1)
 
     def _terminate(self, signal_id):
@@ -168,6 +167,9 @@ class Dataset(AppLogger):
             raise self.exceptions[task_name]
 
     def __str__(self):
+        return '%s(name=%s)' % (self.__class__.__name__, self.name)
+
+    def report(self):
         s = self.name
         pid = self.most_recent_proc.get('pid')
         if pid:
@@ -176,8 +178,6 @@ class Dataset(AppLogger):
         if stages:
             s += ' -- ' + ', '.join(stages)
         return s
-
-    __repr__ = __str__
 
     def __lt__(self, other):
         return self.name < other.name
@@ -198,11 +198,6 @@ class NoCommunicationDataset(Dataset):
 
     def _is_ready(self):
         pass
-
-    def __str__(self):
-        return self.name
-
-    __repr__ = __str__
 
 
 class RunDataset(Dataset):
@@ -416,12 +411,12 @@ class SampleDataset(Dataset):
     def _is_ready(self):
         return self.data_threshold and int(self._amount_data()) > int(self.data_threshold)
 
-    def __str__(self):
+    def report(self):
         runs = sorted(set(r.get(ELEMENT_RUN_NAME) for r in self.run_elements))
         non_useable_runs = sorted(set(r.get(ELEMENT_RUN_NAME) for r in self.non_useable_run_elements))
 
         s = '%s  (%s / %s  from %s) ' % (
-            super().__str__(), self._amount_data(), self.data_threshold, ', '.join(runs)
+            super().report(), self._amount_data(), self.data_threshold, ', '.join(runs)
         )
         if non_useable_runs:
             s += '(non useable run elements in %s)' % ', '.join(non_useable_runs)
@@ -557,42 +552,45 @@ class MostRecentProc:
             raise RestCommunicationError('Sync failed: ' + str(patch_content))
 
     def update_entity(self, **kwargs):
-        with self.lock:
-            if not self.entity:  # initialise self._entity with database content, or {} if none available
-                self.initialise_entity()  # if self._entity == {}, then initialise and push to database
+        if not self.entity:  # initialise self._entity with database content, or {} if none available
+            self.initialise_entity()  # if self._entity == {}, then initialise and push to database
 
-            self.entity.update(kwargs)
-            self.sync()
+        self.entity.update(kwargs)
+        self.sync()
 
     def change_status(self, status):
-        self.update_entity(status=status)
+        with self.lock:
+            self.update_entity(status=status)
 
     def start(self):
-        self.update_entity(status=DATASET_PROCESSING, pid=os.getpid())
+        with self.lock:
+            self.update_entity(status=DATASET_PROCESSING, pid=os.getpid())
 
     def finish(self, status):
-        self.update_entity(status=status, pid=None, end_date=self._now())
+        with self.lock:
+            self.update_entity(status=status, pid=None, end_date=self._now())
 
     def start_stage(self, stage_name):
-        doc = rest_communication.get_document(
-            'analysis_driver_stages',
-            where={'stage_id': self._stage_id(stage_name)}
-        )
-        if doc:
-            rest_communication.patch_entry(
+        with self.lock:
+            doc = rest_communication.get_document(
                 'analysis_driver_stages',
-                {'date_started': self._now(), 'date_finished': None, 'exit_status': None},
-                'stage_id', self._stage_id(stage_name)
+                where={'stage_id': self._stage_id(stage_name)}
             )
-        else:
-            rest_communication.post_entry(
-                'analysis_driver_stages',
-                {'stage_id': self._stage_id(stage_name), 'date_started': self._now(),
-                 'stage_name': stage_name, 'analysis_driver_proc': self.proc_id}
-            )
-            stages = self.entity.get('stages', [])
-            stages.append(self._stage_id(stage_name))
-            self.update_entity(stages=stages)
+            if doc:
+                rest_communication.patch_entry(
+                    'analysis_driver_stages',
+                    {'date_started': self._now(), 'date_finished': None, 'exit_status': None},
+                    'stage_id', self._stage_id(stage_name)
+                )
+            else:
+                rest_communication.post_entry(
+                    'analysis_driver_stages',
+                    {'stage_id': self._stage_id(stage_name), 'date_started': self._now(),
+                     'stage_name': stage_name, 'analysis_driver_proc': self.proc_id}
+                )
+                stages = self.entity.get('stages', [])
+                stages.append(self._stage_id(stage_name))
+                self.update_entity(stages=stages)
 
     def end_stage(self, stage_name, exit_status=0):
         rest_communication.patch_entry(

--- a/analysis_driver/dataset_scanner.py
+++ b/analysis_driver/dataset_scanner.py
@@ -33,7 +33,7 @@ class DatasetScanner(AppLogger):
         scan = self.scan_datasets(*statuses)
 
         for status in statuses:
-            datasets = [str(d) for d in scan.get(status, [])]
+            datasets = [d.report() for d in scan.get(status, [])]
             if datasets:
                 out.append('=== ' + status + ' ===')
                 out.append('\n'.join(datasets))

--- a/analysis_driver/segmentation.py
+++ b/analysis_driver/segmentation.py
@@ -30,6 +30,7 @@ class EGCGEncoder(json.JSONEncoder):
 class BasicStage(luigi.Task, AppLogger):
     __stagename__ = None
     exit_status = None
+    retry_count = 1  # turn off automatic retrying upon task failure
  
     previous_stages = EGCGListParameter(default=[])
     dataset = EGCGParameter()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -174,9 +174,9 @@ class TestDataset(TestAnalysisDriver):
         mocked_end_stage.assert_called_with('a_stage', 0)
         self.dataset.ntf.end_stage.assert_called_with('a_stage', 0)
 
-    def test_str(self):
+    def test_report(self):
         with patched_stages:
-            assert str(self.dataset) == 'test_dataset -- this, that, other'
+            assert self.dataset.report() == 'test_dataset -- this, that, other'
 
     def setup_dataset(self):
         with patched_get_docs():
@@ -335,13 +335,11 @@ class TestSampleDataset(TestDataset):
         assert self.dataset._is_ready()
         assert mocked_instance.call_count == 1  # even after 2 calls to data_threshold
 
-    def test_str(self):
+    def test_report(self):
         expected_str = 'test_dataset -- this, that, other  (480 / 1000000000  from a_run_id, another_run_id) (non useable run elements in a_run_id, another_run_id)'
         self.dataset._data_threshold = None
         with patched_get_docs(self.dataset.run_elements), patched_expected_yield(), patched_stages:
-            print(expected_str)
-            print(str(self.dataset))
-            assert str(self.dataset) == expected_str
+            assert self.dataset.report() == expected_str
 
     def setup_dataset(self):
         with patched_get_docs():


### PR DESCRIPTION
Concurrent stages have each been overwriting `MostRecentProc.entity` with stage IDs because `MostRecentProc.start_stage` was not entirely locked. We were also finding stages that were failing and re-running over and over, which we found to be a Luigi feature. These have been fixed.

Also separated the `SampleDataset` representation we use in `--report` (which calls the Rest API via `running_stages`) from its `__repr__` (which is called many times by Luigi).

Closes #256.
