### PR TITLE
Fastq filterer fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 Changelog for Analysis-Driver
 =============================
 
-0.16 (unreleased)
+0.15.3 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fixed fastq_filterer stats file bug and removed workaround from 0.15.1
 
 
 0.15.2 (2017-05-29)
 -------------------
 
-- Change tools writting to /tmp in Samtools depth and Genotype Validation.
+- Change tools writing to /tmp in Samtools depth and Genotype Validation.
 
 
 0.15.1 (2017-05-24)
@@ -23,7 +23,7 @@ Changelog for Analysis-Driver
 -----------------
 
  - All sample and project processes are now segmented using Luigi
- - Allow filtering/Trimming of bad quality runs in demultiplexing 
+ - Allow filtering/trimming of bad quality runs in demultiplexing 
  - Fix analysis driver --stop and Error handling
 
 0.14.3 (2017-04-28)

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -47,10 +47,10 @@ def seqtk_fqchk(fastq_file):
 def fq_filt_prelim_cmd():
     cmd = (
         'function run_filterer {{',  # double up { and } to escape them for str.format()
-        'i1=$1', 'i2=$2', 'o1=$3', 'o2=$4', 'fifo_1=$5', 'fifo_2=$6', 'log_file=$7',
+        'i1=$1', 'i2=$2', 'o1=$3', 'o2=$4', 'fifo_1=$5', 'fifo_2=$6',
 
         'mkfifo $fifo_1', 'mkfifo $fifo_2',
-        '{ff} --i1 $i1 --i2 $i2 --o1 $fifo_1 --o2 $fifo_2 --threshold {threshold} $* > $log_file 2>&1 &',
+        '{ff} --i1 $i1 --i2 $i2 --o1 $fifo_1 --o2 $fifo_2 --threshold {threshold} $* &',
         'fq_filt_pid=$!',
         '{pigz} -c -p {pzt} $fifo_1 > $o1 &',
         'pigz_r1_pid=$!',
@@ -99,10 +99,9 @@ def fastq_filterer_and_pigz_in_place(fastq_file_pair, tiles_to_filter=None, trim
     o2 = fifo_2 + '.gz'
 
     stats_file = base_1.replace('_R1_001', '') + '_fastqfilterer.stats'
-    log_file = base_1.replace('_R1_001', '') + '.log'
 
-    fastq_filterer_cmd = 'run_filterer {0} {1} {2} {3} {4} {5} {6} --stats_file {7}'.format(
-        i1, i2, o1, o2, fifo_1, fifo_2, log_file, stats_file
+    fastq_filterer_cmd = 'run_filterer {0} {1} {2} {3} {4} {5} --stats_file {6}'.format(
+        i1, i2, o1, o2, fifo_1, fifo_2, stats_file
     )
 
     if tiles_to_filter:

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -44,50 +44,75 @@ def seqtk_fqchk(fastq_file):
     return cmd
 
 
-def fastq_filterer_and_pigz_in_place(fastq_file_pair, pigz_threads=10, tiles_to_filter=None, trim_r1=None, trim_r2=None):
+def fq_filt_prelim_cmd():
+    cmd = (
+        'function run_filterer {{',  # double up { and } to escape them for str.format()
+        'i1=$1', 'i2=$2', 'o1=$3', 'o2=$4', 'fifo_1=$5', 'fifo_2=$6', 'log_file=$7',
+
+        'mkfifo $fifo_1', 'mkfifo $fifo_2',
+        '{ff} --i1 $i1 --i2 $i2 --o1 $fifo_1 --o2 $fifo_2 --threshold {threshold} $* > $log_file 2>&1 &',
+        'fq_filt_pid=$!',
+        '{pigz} -c -p {pzt} $fifo_1 > $o1 &',
+        'pigz_r1_pid=$!',
+        '{pigz} -c -p {pzt} $fifo_2 > $o2 &',
+        'pigz_r2_pid=$!',
+
+        'exit_status=0',
+        'wait $fq_filt_pid',
+        'exit_status=$[$exit_status + $?]',
+        'wait $pigz_r1_pid',
+        'exit_status=$[$exit_status + $?]',
+        'wait $pigz_r2_pid',
+        'exit_status=$[$exit_status + $?]',
+        'rm $fifo_1 $fifo_2',
+        'if [ $exit_status == 0 ]; then mv $o1 $i1; mv $o2 $i2; fi',
+        '(exit $exit_status)',
+        '}}'
+    )
+    return '\n'.join(cmd).format(
+        ff=cfg['tools']['fastq-filterer'],
+        threshold=cfg.query('fastq_filterer', 'min_length', ret_default='36'),
+        pigz=cfg.query('tools', 'pigz', ret_default='pigz'),
+        pzt=10  # two pigz processes run, so pigz threads here will be doubled
+    )
+
+
+def fastq_filterer_and_pigz_in_place(fastq_file_pair, tiles_to_filter=None, trim_r1=None, trim_r2=None):
     """
     :param tuple[str,str] fastq_file_pair: Paired-end fastqs to filter
-    :param int pigz_threads: nthreads to assign pigz (note that two pigzs run, so this is will be doubled)
+    :param list tiles_to_filter: Tile IDs for reads to remove regardless of length
+    :param trim_r1: Maximum length to trim R1 to
+    :param trim_r2: As trim_r1, but for R2
     Run fastq filterer on a pair of fastqs, removing pairs where one is shorter than 36 bases
     """
     if len(fastq_file_pair) != 2:
         raise AnalysisDriverError('fastq-filterer only supports paired fastq files')
 
-    f1, f2 = sorted(fastq_file_pair)
-    f1_base = f1.replace('.fastq.gz', '')
-    int1 = f1_base + '_filtered.fastq'
-    of1 = f1_base + '_filtered.fastq.gz'
-    f2_base = f2.replace('.fastq.gz', '')
-    int2 = f2_base + '_filtered.fastq'
-    of2 = f2_base + '_filtered.fastq.gz'
-    stats_file = f1_base.replace('_R1_001', '') + '_fastqfilterer.stats'
-    cmds = ['mkfifo ' + int1, 'mkfifo ' + int2]
-    fastq_filterer_cmd = '{ff} --stats_file {stats} --i1 {f1} --i2 {f2} --o1 {int1} --o2 {int2} --threshold {lent}'
+    i1, i2 = sorted(fastq_file_pair)
+
+    base_1 = i1.replace('.fastq.gz', '')
+    fifo_1 = base_1 + '_filtered.fastq'
+    o1 = fifo_1 + '.gz'
+
+    base_2 = i2.replace('.fastq.gz', '')
+    fifo_2 = base_2 + '_filtered.fastq'
+    o2 = fifo_2 + '.gz'
+
+    stats_file = base_1.replace('_R1_001', '') + '_fastqfilterer.stats'
+    log_file = base_1.replace('_R1_001', '') + '.log'
+
+    fastq_filterer_cmd = 'run_filterer {0} {1} {2} {3} {4} {5} {6} --stats_file {7}'.format(
+        i1, i2, o1, o2, fifo_1, fifo_2, log_file, stats_file
+    )
+
     if tiles_to_filter:
         fastq_filterer_cmd += ' --remove_tiles %s' % (','.join([str(t) for t in tiles_to_filter]))
     if trim_r1:
-        fastq_filterer_cmd += ' --trim_r1 %s' % (trim_r1)
+        fastq_filterer_cmd += ' --trim_r1 %s' % trim_r1
     if trim_r2:
-        fastq_filterer_cmd += ' --trim_r2 %s' % (trim_r2)
-    c = (
-        'set -e; ' + fastq_filterer_cmd +' & '
-        '{pz} -c -p {pzt} {int1} > {of1} & '
-        '{pz} -c -p {pzt} {int2} > {of2}'
-    )
-    cmds.append(
-        c.format(ff=cfg.query('tools', 'fastq-filterer'), pz=cfg.query('tools', 'pigz', ret_default='pigz'),
-                 pzt=pigz_threads, f1=f1, f2=f2, of1=of1, of2=of2, int1=int1, int2=int2, stats=stats_file,
-                 lent=cfg.query('fastq_filterer', 'min_length', ret_default='36'))
-    )
-    cmds.extend(['EXIT_CODE=$?', 'rm ' + int1 + ' ' + int2])
+        fastq_filterer_cmd += ' --trim_r2 %s' % trim_r2
 
-    # replace the original files with the new files to keep things clean
-    cmds.append('(exit $EXIT_CODE) && mv %s %s' % (of1, f1))
-    cmds.append('(exit $EXIT_CODE) && mv %s %s' % (of2, f2))
-    cmds.append('(exit $EXIT_CODE)')
-    for c in cmds:
-        app_logger.debug('Writing: ' + c)
-    return '\n'.join(cmds)
+    return fastq_filterer_cmd
 
 
 def bwa_mem_samblaster(fastq_pair, reference, expected_output_bam, read_group=None, thread=16):

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -66,7 +66,7 @@ def _parse_args():
     bad_cycle_tile_parser.add_argument('--window_size', type=int, default=50)
     bad_cycle_tile_parser.add_argument('--tile_quality_threshold', type=int, default=20)
     bad_cycle_tile_parser.add_argument('--cycle_quality_threshold', type=int, default=20)
-    bad_cycle_tile_parser.set_defaults(func=detect_bad_cycle_tile_in_run)
+    bad_cycle_tile_parser.set_defaults(func=detect_bad_cycles_and_tiles)
 
     return parser.parse_args()
 
@@ -158,7 +158,7 @@ def relatedness(dataset, args):
     r.run()
 
 
-def detect_bad_cycle_tile_in_run(dataset, args):
+def detect_bad_cycles_and_tiles(dataset, args):
     cfg.merge(cfg['run'])
     dataset = RunDataset(args.dataset_name)
     d = qc.BadTileCycleDetector(
@@ -167,8 +167,8 @@ def detect_bad_cycle_tile_in_run(dataset, args):
         tile_quality_threshold=args.tile_quality_threshold,
         cycle_quality_threshold=args.cycle_quality_threshold
     )
-    bad_tiles = d.detect_bad_tile()
-    bad_cycle = d.detect_bad_cycle()
+    bad_tiles = d.detect_bad_tiles()
+    bad_cycle = d.detect_bad_cycles()
     for lane in sorted(set(list(bad_tiles) + list(bad_cycle))):
         print('Lane %s' % lane)
         if lane in bad_cycle:

--- a/tests/test_bash_commands.py
+++ b/tests/test_bash_commands.py
@@ -127,19 +127,9 @@ def test_seqtk_fqchk():
 
 
 def test_fastq_filterer_and_pigz_in_place():
-    fastq_file_pair = ('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz')
-    expected_command = (
-        'mkfifo RE_R1_001_filtered.fastq\n'
-        'mkfifo RE_R2_001_filtered.fastq\n'
-        'set -e; path/to/fastq-filterer --stats_file RE_fastqfilterer.stats --i1 RE_R1_001.fastq.gz --i2 RE_R2_001.fastq.gz --o1 RE_R1_001_filtered.fastq '
-        '--o2 RE_R2_001_filtered.fastq --threshold 36 & '
-        'pigz -c -p 10 RE_R1_001_filtered.fastq > RE_R1_001_filtered.fastq.gz & '
-        'pigz -c -p 10 RE_R2_001_filtered.fastq > RE_R2_001_filtered.fastq.gz\n'
-        'EXIT_CODE=$?\n'
-        'rm RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq\n'
-        '(exit $EXIT_CODE) && mv RE_R1_001_filtered.fastq.gz RE_R1_001.fastq.gz\n'
-        '(exit $EXIT_CODE) && mv RE_R2_001_filtered.fastq.gz RE_R2_001.fastq.gz\n'
-        '(exit $EXIT_CODE)'
+    exp = (
+        'run_filterer RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
+        'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq '
+        'RE.log --stats_file RE_fastqfilterer.stats'
     )
-    command = bash_commands.fastq_filterer_and_pigz_in_place(fastq_file_pair)
-    assert command == expected_command
+    assert bash_commands.fastq_filterer_and_pigz_in_place(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz')) == exp

--- a/tests/test_bash_commands.py
+++ b/tests/test_bash_commands.py
@@ -130,6 +130,6 @@ def test_fastq_filterer_and_pigz_in_place():
     exp = (
         'run_filterer RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
         'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq '
-        'RE.log --stats_file RE_fastqfilterer.stats'
+        '--stats_file RE_fastqfilterer.stats'
     )
     assert bash_commands.fastq_filterer_and_pigz_in_place(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz')) == exp

--- a/tests/test_pipelines/test_demultiplexing.py
+++ b/tests/test_pipelines/test_demultiplexing.py
@@ -1,16 +1,9 @@
 from unittest.mock import Mock, patch
-
-from analysis_driver.dataset import NoCommunicationDataset
 from analysis_driver.pipelines.demultiplexing import FastqFilter
-from analysis_driver.quality_control.detect_bad_cycles_tiles import BadTileCycleDetector
 from tests.test_analysisdriver import TestAnalysisDriver, NamedMock
 
 
 class TestFastqFilter(TestAnalysisDriver):
-
-    def setUp(self):
-        self.dataset = NoCommunicationDataset('test')
-
     def test_run(self):
         run_info = Mock(reads=Mock(
             upstream_read=Mock(attrib={'NumCycles': '151'}),
@@ -19,10 +12,11 @@ class TestFastqFilter(TestAnalysisDriver):
         ))
         dataset = NamedMock(
             real_name='test',
-            lane_metrics=[{'pc_q30':73, 'lane_number': 3}, {'pc_q30':73, 'lane_number': 4}],
+            lane_metrics=[{'pc_q30': 73, 'lane_number': 3}, {'pc_q30': 73, 'lane_number': 4}],
             run_info=run_info
         )
-        f=FastqFilter(dataset=dataset)
+        f = FastqFilter(dataset=dataset)
+
         results_fastq = [
             [('fastq_L1_R1_001.fastq.gz', 'fastq_L1_R2_001.fastq.gz')],
             [('fastq_L2_R1_001.fastq.gz', 'fastq_L2_R2_001.fastq.gz')],
@@ -31,34 +25,30 @@ class TestFastqFilter(TestAnalysisDriver):
             [('fastq_L5_R1_001.fastq.gz', 'fastq_L5_R2_001.fastq.gz')],
             [('fastq_L6_R1_001.fastq.gz', 'fastq_L6_R2_001.fastq.gz')],
             [('fastq_L7_R1_001.fastq.gz', 'fastq_L7_R2_001.fastq.gz')],
-            [('fastq_L8_R1_001.fastq.gz', 'fastq_L8_R2_001.fastq.gz')],
-
+            [('fastq_L8_R1_001.fastq.gz', 'fastq_L8_R2_001.fastq.gz')]
         ]
-        patch_find = patch('analysis_driver.pipelines.demultiplexing.find_all_fastq_pairs_for_lane',
-                           side_effect=results_fastq + results_fastq)
         patch_executor = patch('analysis_driver.pipelines.demultiplexing.executor.execute')
         patch_detector = patch('analysis_driver.pipelines.demultiplexing.BadTileCycleDetector')
-        patch_sleep = patch('analysis_driver.pipelines.demultiplexing.sleep')
-        with patch_find, patch_executor as pexecute, patch_detector as pdetector, patch_sleep:
+        patch_find = patch('analysis_driver.pipelines.demultiplexing.find_all_fastq_pairs_for_lane',
+                           side_effect=results_fastq + results_fastq)
+
+        with patch_find, patch_executor as pexecute, patch_detector as pdetector:
             instance = pdetector.return_value
-            instance.detect_bad_tile.return_value = {3: [1101]}
-            instance.detect_bad_cycle.return_value = {4: [310, 308, 307, 309]}
+            instance.detect_bad_tiles.return_value = {3: [1101]}
+            instance.detect_bad_cycles.return_value = {4: [310, 308, 307, 309]}
             f._run()
-            expected_call_L3 = """mkfifo fastq_L3_R1_001_filtered.fastq
-mkfifo fastq_L3_R2_001_filtered.fastq
-set -e; path/to/fastq-filterer --stats_file fastq_L3_fastqfilterer.stats --i1 fastq_L3_R1_001.fastq.gz --i2 fastq_L3_R2_001.fastq.gz --o1 fastq_L3_R1_001_filtered.fastq --o2 fastq_L3_R2_001_filtered.fastq --threshold 36 --remove_tiles 1101 & pigz -c -p 10 fastq_L3_R1_001_filtered.fastq > fastq_L3_R1_001_filtered.fastq.gz & pigz -c -p 10 fastq_L3_R2_001_filtered.fastq > fastq_L3_R2_001_filtered.fastq.gz
-EXIT_CODE=$?
-rm fastq_L3_R1_001_filtered.fastq fastq_L3_R2_001_filtered.fastq
-(exit $EXIT_CODE) && mv fastq_L3_R1_001_filtered.fastq.gz fastq_L3_R1_001.fastq.gz
-(exit $EXIT_CODE) && mv fastq_L3_R2_001_filtered.fastq.gz fastq_L3_R2_001.fastq.gz
-(exit $EXIT_CODE)"""
-            expected_call_L4 = """mkfifo fastq_L4_R1_001_filtered.fastq
-mkfifo fastq_L4_R2_001_filtered.fastq
-set -e; path/to/fastq-filterer --stats_file fastq_L4_fastqfilterer.stats --i1 fastq_L4_R1_001.fastq.gz --i2 fastq_L4_R2_001.fastq.gz --o1 fastq_L4_R1_001_filtered.fastq --o2 fastq_L4_R2_001_filtered.fastq --threshold 36 --trim_r2 147 & pigz -c -p 10 fastq_L4_R1_001_filtered.fastq > fastq_L4_R1_001_filtered.fastq.gz & pigz -c -p 10 fastq_L4_R2_001_filtered.fastq > fastq_L4_R2_001_filtered.fastq.gz
-EXIT_CODE=$?
-rm fastq_L4_R1_001_filtered.fastq fastq_L4_R2_001_filtered.fastq
-(exit $EXIT_CODE) && mv fastq_L4_R1_001_filtered.fastq.gz fastq_L4_R1_001.fastq.gz
-(exit $EXIT_CODE) && mv fastq_L4_R2_001_filtered.fastq.gz fastq_L4_R2_001.fastq.gz
-(exit $EXIT_CODE)"""
-            assert expected_call_L3 == pexecute.call_args[0][2]
-            assert expected_call_L4 == pexecute.call_args[0][3]
+
+            expected_call_l3 = (
+                'run_filterer fastq_L3_R1_001.fastq.gz fastq_L3_R2_001.fastq.gz '
+                'fastq_L3_R1_001_filtered.fastq.gz fastq_L3_R2_001_filtered.fastq.gz '
+                'fastq_L3_R1_001_filtered.fastq fastq_L3_R2_001_filtered.fastq '
+                'fastq_L3.log --stats_file fastq_L3_fastqfilterer.stats --remove_tiles 1101'
+            )
+            expected_call_l4 = (
+                'run_filterer fastq_L4_R1_001.fastq.gz fastq_L4_R2_001.fastq.gz '
+                'fastq_L4_R1_001_filtered.fastq.gz fastq_L4_R2_001_filtered.fastq.gz '
+                'fastq_L4_R1_001_filtered.fastq fastq_L4_R2_001_filtered.fastq '
+                'fastq_L4.log --stats_file fastq_L4_fastqfilterer.stats --trim_r2 147'
+            )
+            assert expected_call_l3 == pexecute.call_args[0][2]
+            assert expected_call_l4 == pexecute.call_args[0][3]

--- a/tests/test_pipelines/test_demultiplexing.py
+++ b/tests/test_pipelines/test_demultiplexing.py
@@ -42,13 +42,13 @@ class TestFastqFilter(TestAnalysisDriver):
                 'run_filterer fastq_L3_R1_001.fastq.gz fastq_L3_R2_001.fastq.gz '
                 'fastq_L3_R1_001_filtered.fastq.gz fastq_L3_R2_001_filtered.fastq.gz '
                 'fastq_L3_R1_001_filtered.fastq fastq_L3_R2_001_filtered.fastq '
-                'fastq_L3.log --stats_file fastq_L3_fastqfilterer.stats --remove_tiles 1101'
+                '--stats_file fastq_L3_fastqfilterer.stats --remove_tiles 1101'
             )
             expected_call_l4 = (
                 'run_filterer fastq_L4_R1_001.fastq.gz fastq_L4_R2_001.fastq.gz '
                 'fastq_L4_R1_001_filtered.fastq.gz fastq_L4_R2_001_filtered.fastq.gz '
                 'fastq_L4_R1_001_filtered.fastq fastq_L4_R2_001_filtered.fastq '
-                'fastq_L4.log --stats_file fastq_L4_fastqfilterer.stats --trim_r2 147'
+                '--stats_file fastq_L4_fastqfilterer.stats --trim_r2 147'
             )
             assert expected_call_l3 == pexecute.call_args[0][2]
             assert expected_call_l4 == pexecute.call_args[0][3]

--- a/tests/test_quality_control/test_detect_bad_cycles_tiles.py
+++ b/tests/test_quality_control/test_detect_bad_cycles_tiles.py
@@ -75,7 +75,7 @@ class TestBadTileCycleDetector(TestAnalysisDriver):
         ]
         self.detector.window_size = 2
         self.detector.all_lanes = {1: ({'1101': list_q_hist1, '1102': list_q_hist2}, {})}
-        assert dict(self.detector.detect_bad_tile()) == {1: ['1101']}
+        assert dict(self.detector.detect_bad_tiles()) == {1: ['1101']}
 
     def test_detect_bad_cycles(self):
         list_q_hist1 = [
@@ -93,4 +93,4 @@ class TestBadTileCycleDetector(TestAnalysisDriver):
             (0, 1, 1, 1, 1, 1, 10)
         ]
         self.detector.all_lanes = {1: ({}, {'1': list_q_hist1, '2': list_q_hist2})}
-        assert dict(self.detector.detect_bad_cycle()) == {1: ['1']}
+        assert dict(self.detector.detect_bad_cycles()) == {1: ['1']}


### PR DESCRIPTION
Fixes a bug in the fastq filterer stage, where sometimes the stats file was not being written. Now, fastq_filterer and pigz are all run in parallel, and the `wait` Bash command is used to wait on all child processes before Slurm exits. Also refactored some of the FastqFilter stage and the generated fastq_filterer.slurm script.