### PR TITLE
Keep original versions of filtered fastqs

### DIFF
--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -66,7 +66,7 @@ def fq_filt_prelim_cmd():
         'wait $pigz_r2_pid',
         'exit_status=$[$exit_status + $?]',
         'rm $fifo_1 $fifo_2',
-        'if [ $exit_status == 0]; then'
+        'if [ $exit_status == 0 ]; then'
         'if [ "$strategy" == "keep_originals" ]; then mv $i1 $i1.original; mv $i2 $i2.original; fi',
         'mv $o1 $i1; mv $o2 $i2',
         'fi',

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -48,10 +48,10 @@ def seqtk_fqchk(fastq_file):
 def fq_filt_prelim_cmd():
     cmd = (
         'function run_filterer {{',  # double up { and } to escape them for str.format()
-        'i1=$1', 'i2=$2', 'o1=$3', 'o2=$4', 'fifo_1=$5', 'fifo_2=$6',
-
+        'strategy=$1', 'i1=$2', 'i2=$3', 'o1=$4', 'o2=$5', 'fifo_1=$6', 'fifo_2=$7', 'stats_file=$8',
+        'shift 7',
         'mkfifo $fifo_1', 'mkfifo $fifo_2',
-        '{ff} --i1 $i1 --i2 $i2 --o1 $fifo_1 --o2 $fifo_2 --threshold {threshold} $* &',
+        '{ff} --i1 $i1 --i2 $i2 --o1 $fifo_1 --o2 $fifo_2 --threshold {threshold} --stats_file $stats_file $* &',
         'fq_filt_pid=$!',
         '{pigz} -c -p {pzt} $fifo_1 > $o1 &',
         'pigz_r1_pid=$!',
@@ -66,7 +66,10 @@ def fq_filt_prelim_cmd():
         'wait $pigz_r2_pid',
         'exit_status=$[$exit_status + $?]',
         'rm $fifo_1 $fifo_2',
-        'if [ $exit_status == 0 ]; then mv $o1 $i1; mv $o2 $i2; fi',
+        'if [ $exit_status == 0]; then'
+        'if [ "$strategy" == "keep_originals" ]; then mv $i1 $i1.original; mv $i2 $i2.original; fi',
+        'mv $o1 $i1; mv $o2 $i2',
+        'fi',
         '(exit $exit_status)',
         '}}'
     )
@@ -78,7 +81,7 @@ def fq_filt_prelim_cmd():
     )
 
 
-def fastq_filterer_and_pigz_in_place(fastq_file_pair, tiles_to_filter=None, trim_r1=None, trim_r2=None):
+def fastq_filterer(fastq_file_pair, tiles_to_filter=None, trim_r1=None, trim_r2=None):
     """
     :param tuple[str,str] fastq_file_pair: Paired-end fastqs to filter
     :param list tiles_to_filter: Tile IDs for reads to remove regardless of length
@@ -101,18 +104,23 @@ def fastq_filterer_and_pigz_in_place(fastq_file_pair, tiles_to_filter=None, trim
 
     stats_file = base_1.replace('_R1_001', '') + '_fastqfilterer.stats'
 
-    fastq_filterer_cmd = 'run_filterer {0} {1} {2} {3} {4} {5} --stats_file {6}'.format(
-        i1, i2, o1, o2, fifo_1, fifo_2, stats_file
-    )
+    cmd = 'run_filterer'
+
+    if any((tiles_to_filter, trim_r1, trim_r2)):
+        cmd += ' keep_originals'
+    else:
+        cmd += ' in_place'
+
+    cmd += ' {0} {1} {2} {3} {4} {5} {6}'.format(i1, i2, o1, o2, fifo_1, fifo_2, stats_file)
 
     if tiles_to_filter:
-        fastq_filterer_cmd += ' --remove_tiles %s' % (','.join([str(t) for t in tiles_to_filter]))
+        cmd += ' --remove_tiles %s' % (','.join([str(t) for t in tiles_to_filter]))
     if trim_r1:
-        fastq_filterer_cmd += ' --trim_r1 %s' % trim_r1
+        cmd += ' --trim_r1 %s' % trim_r1
     if trim_r2:
-        fastq_filterer_cmd += ' --trim_r2 %s' % trim_r2
+        cmd += ' --trim_r2 %s' % trim_r2
 
-    return fastq_filterer_cmd
+    return cmd
 
 
 def bwa_mem_samblaster(fastq_pair, reference, expected_output_bam, read_group=None, thread=16):

--- a/integration_tests/mocked_data.py
+++ b/integration_tests/mocked_data.py
@@ -125,6 +125,13 @@ def patch_pipeline(species='Homo sapiens', analysis_type='Variant Calling gatk')
     _patch('quality_control.genotype_validation.clarity.get_sample_names_from_project', return_value=set())
     _patch('quality_control.genotype_validation.clarity.get_sample_genotype', return_value=set())
     _patch('quality_control.well_duplicates.WellDuplicates._welldups_cmd', new=_fake_welldups_cmd)
+    _patch(
+        'pipelines.demultiplexing.BadTileCycleDetector',
+        return_value=Mock(
+            detect_bad_cycles=Mock(return_value={5: [309, 310]}),
+            detect_bad_tiles=Mock(return_value={})
+        )
+    )
 
     yield
 

--- a/tests/test_bash_commands.py
+++ b/tests/test_bash_commands.py
@@ -119,10 +119,13 @@ def test_seqtk_fqchk():
     assert bash_commands.seqtk_fqchk(fastq_file) == expected
 
 
-def test_fastq_filterer_and_pigz_in_place():
-    exp = (
-        'run_filterer RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
-        'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq '
-        '--stats_file RE_fastqfilterer.stats'
+def test_fastq_filterer():
+    assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz')) == (
+        'run_filterer in_place RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
+        'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats'
     )
-    assert bash_commands.fastq_filterer_and_pigz_in_place(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz')) == exp
+    assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'), trim_r1=149) == (
+        'run_filterer keep_originals RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
+        'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats'
+        ' --trim_r1 149'
+    )

--- a/tests/test_pipelines/test_demultiplexing.py
+++ b/tests/test_pipelines/test_demultiplexing.py
@@ -19,20 +19,16 @@ class TestFastqFilter(TestAnalysisDriver):
         )
         f = FastqFilter(dataset=dataset)
 
-        results_fastq = [
-            [('fastq_L1_R1_001.fastq.gz', 'fastq_L1_R2_001.fastq.gz')],
-            [('fastq_L2_R1_001.fastq.gz', 'fastq_L2_R2_001.fastq.gz')],
-            [('fastq_L3_R1_001.fastq.gz', 'fastq_L3_R2_001.fastq.gz')],
-            [('fastq_L4_R1_001.fastq.gz', 'fastq_L4_R2_001.fastq.gz')],
-            [('fastq_L5_R1_001.fastq.gz', 'fastq_L5_R2_001.fastq.gz')],
-            [('fastq_L6_R1_001.fastq.gz', 'fastq_L6_R2_001.fastq.gz')],
-            [('fastq_L7_R1_001.fastq.gz', 'fastq_L7_R2_001.fastq.gz')],
-            [('fastq_L8_R1_001.fastq.gz', 'fastq_L8_R2_001.fastq.gz')]
+        fake_fastq_pairs = [
+            [('L1_R1_001.fastq.gz', 'L1_R2_001.fastq.gz')], [('L2_R1_001.fastq.gz', 'L2_R2_001.fastq.gz')],
+            [('L3_R1_001.fastq.gz', 'L3_R2_001.fastq.gz')], [('L4_R1_001.fastq.gz', 'L4_R2_001.fastq.gz')],
+            [('L5_R1_001.fastq.gz', 'L5_R2_001.fastq.gz')], [('L6_R1_001.fastq.gz', 'L6_R2_001.fastq.gz')],
+            [('L7_R1_001.fastq.gz', 'L7_R2_001.fastq.gz')], [('L8_R1_001.fastq.gz', 'L8_R2_001.fastq.gz')]
         ]
         patch_executor = patch('analysis_driver.pipelines.demultiplexing.executor.execute')
         patch_detector = patch('analysis_driver.pipelines.demultiplexing.BadTileCycleDetector')
         patch_find = patch('analysis_driver.pipelines.demultiplexing.find_all_fastq_pairs_for_lane',
-                           side_effect=results_fastq + results_fastq)
+                           side_effect=fake_fastq_pairs + fake_fastq_pairs)
 
         with patch_find, patch_executor as pexecute, patch_detector as pdetector:
             instance = pdetector.return_value
@@ -40,17 +36,20 @@ class TestFastqFilter(TestAnalysisDriver):
             instance.detect_bad_cycles.return_value = {4: [310, 308, 307, 309]}
             f._run()
 
+            expected_call_l2 = (
+                'run_filterer in_place L2_R1_001.fastq.gz L2_R2_001.fastq.gz L2_R1_001_filtered.fastq.gz '
+                'L2_R2_001_filtered.fastq.gz L2_R1_001_filtered.fastq L2_R2_001_filtered.fastq L2_fastqfilterer.stats'
+            )
             expected_call_l3 = (
-                'run_filterer fastq_L3_R1_001.fastq.gz fastq_L3_R2_001.fastq.gz '
-                'fastq_L3_R1_001_filtered.fastq.gz fastq_L3_R2_001_filtered.fastq.gz '
-                'fastq_L3_R1_001_filtered.fastq fastq_L3_R2_001_filtered.fastq '
-                '--stats_file fastq_L3_fastqfilterer.stats --remove_tiles 1101'
+                'run_filterer keep_originals L3_R1_001.fastq.gz L3_R2_001.fastq.gz L3_R1_001_filtered.fastq.gz '
+                'L3_R2_001_filtered.fastq.gz L3_R1_001_filtered.fastq L3_R2_001_filtered.fastq L3_fastqfilterer.stats '
+                '--remove_tiles 1101'
             )
             expected_call_l4 = (
-                'run_filterer fastq_L4_R1_001.fastq.gz fastq_L4_R2_001.fastq.gz '
-                'fastq_L4_R1_001_filtered.fastq.gz fastq_L4_R2_001_filtered.fastq.gz '
-                'fastq_L4_R1_001_filtered.fastq fastq_L4_R2_001_filtered.fastq '
-                '--stats_file fastq_L4_fastqfilterer.stats --trim_r2 147'
+                'run_filterer keep_originals L4_R1_001.fastq.gz L4_R2_001.fastq.gz L4_R1_001_filtered.fastq.gz '
+                'L4_R2_001_filtered.fastq.gz L4_R1_001_filtered.fastq L4_R2_001_filtered.fastq L4_fastqfilterer.stats '
+                '--trim_r2 147'
             )
+            assert expected_call_l2 == pexecute.call_args[0][1]
             assert expected_call_l3 == pexecute.call_args[0][2]
             assert expected_call_l4 == pexecute.call_args[0][3]


### PR DESCRIPTION
When tile or cycle filtering occurs, the original input fastq is now given a `.original` suffix, preventing it from being overwritten. Closes #265.

The end-to-end demultiplexing test now patches BadTileCycleDetector to return bad cycles, making it possible to set a fastq-filterer q30 threshold that will trigger filtering for one sample, and test for the presence of `.original` files.

Also fixed a bug causing repeated args to be passed to fastq-filterer.
