### PR TITLE
User prepared libraries

### DIFF
--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -306,10 +306,7 @@ class RunDataset(Dataset):
                 artifacts = [flowcell.placements[lane]]
             for artifact in artifacts:
                 assert len(artifact.samples) == 1
-                assert len(artifact.reagent_labels) == 1
                 sample = artifact.samples[0]
-                reagent_label = artifact.reagent_labels[0]
-                match = re.match('(\w{4})-(\w{4}) \(([ATCG]{8})-([ATCG]{8})\)', reagent_label)
                 run_element = {
                     ELEMENT_PROJECT_ID: sample.project.name,
                     ELEMENT_SAMPLE_INTERNAL_ID: sample.name,
@@ -318,6 +315,9 @@ class RunDataset(Dataset):
                     ELEMENT_BARCODE: ''
                 }
                 if self.has_barcodes:
+                    assert len(artifact.reagent_labels) == 1
+                    reagent_label = artifact.reagent_labels[0]
+                    match = re.match('(\w{4})-(\w{4}) \(([ATCG]{8})-([ATCG]{8})\)', reagent_label)
                     run_element[ELEMENT_BARCODE] = match.group(3)
                 run_elements.append(run_element)
         return run_elements

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -196,6 +196,9 @@ class TestDataset(TestAnalysisDriver):
             'toolset_version': 0
         }
 
+mocked_lane_user_prep_artifact1 = NamedMock(real_name='art1', reagent_labels=[], samples=[MockedSamples(real_name='sample1')])
+mocked_lane_user_prep_artifact2 = NamedMock(real_name='art2', reagent_labels=[], samples=[MockedSamples(real_name='sample2')])
+
 mocked_lane_artifact1 = NamedMock(real_name='art1', reagent_labels=['D701-D502 (ATTACTCG-ATAGAGGC)'], samples=[MockedSamples(real_name='sample1')])
 mocked_lane_artifact2 = NamedMock(real_name='art2', reagent_labels=['D702-D502 (TCCGGAGA-ATAGAGGC)'], samples=[MockedSamples(real_name='sample2')])
 mocked_lane_artifact3 = NamedMock(real_name='art3', reagent_labels=['D703-D502 (CGCTCATT-ATAGAGGC)'], samples=[MockedSamples(real_name='sample3')])
@@ -241,6 +244,17 @@ mocked_flowcell_pooling = Mock(placements={
     '8:1': mocked_lane_artifact_pool
 })
 
+mocked_flowcell_user_prepared = Mock(placements={
+    '1:1': mocked_lane_user_prep_artifact1,
+    '2:1': mocked_lane_user_prep_artifact2,
+    '3:1': mocked_lane_user_prep_artifact1,
+    '4:1': mocked_lane_user_prep_artifact2,
+    '5:1': mocked_lane_user_prep_artifact1,
+    '6:1': mocked_lane_user_prep_artifact2,
+    '7:1': mocked_lane_user_prep_artifact1,
+    '8:1': mocked_lane_user_prep_artifact2
+})
+
 
 class TestRunDataset(TestDataset):
     def test_is_ready(self):
@@ -263,7 +277,6 @@ class TestRunDataset(TestDataset):
 
     def test_run_elements_from_lims(self):
         d = RunDataset('test_dataset')
-
         with patch('analysis_driver.dataset.clarity.get_run', return_value=MockedRunProcess(container=mocked_flowcell_non_pooling)), \
              patch.object(RunDataset, 'has_barcodes', new_callable=PropertyMock(return_value=False)):
             run_elements = d._run_elements_from_lims()
@@ -274,7 +287,6 @@ class TestRunDataset(TestDataset):
             assert barcodes_len.pop() == 0
 
         d = RunDataset('test_dataset')
-
         with patch('egcg_core.clarity.get_run', return_value=MockedRunProcess(container=mocked_flowcell_pooling)), \
              patch.object(RunDataset, 'has_barcodes', new_callable=PropertyMock(return_value=True)):
             run_elements = d._run_elements_from_lims()
@@ -283,6 +295,16 @@ class TestRunDataset(TestDataset):
             barcodes_len = set(len(r[c.ELEMENT_BARCODE]) for r in run_elements)
             assert len(barcodes_len) == 1
             assert barcodes_len.pop() == 8
+
+        d = RunDataset('test_dataset')
+        with patch('analysis_driver.dataset.clarity.get_run', return_value=MockedRunProcess(container=mocked_flowcell_user_prepared)), \
+             patch.object(RunDataset, 'has_barcodes', new_callable=PropertyMock(return_value=False)):
+            run_elements = d._run_elements_from_lims()
+            assert len(set(r[c.ELEMENT_PROJECT_ID] for r in run_elements)) == 1
+            assert len(set(r[c.ELEMENT_SAMPLE_INTERNAL_ID] for r in run_elements)) == 2
+            barcodes_len = set(len(r[c.ELEMENT_BARCODE]) for r in run_elements)
+            assert len(barcodes_len) == 1
+            assert barcodes_len.pop() == 0
 
     @patch('builtins.open')
     def test_generate_samplesheet(self, mocked_open):


### PR DESCRIPTION
This PR makes sure the reagent label (or barcode) is only required when a barcode is sequenced.
User prepared libraries will not have a reagent label but will only be sequenced in non pooling mode.
This fixes #268 