### PR TITLE
get pipeline instruction for run_qc

### DIFF
--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -243,7 +243,7 @@ class NoCommuncationSampleDataset(NoCommunicationDataset):
 
     def _pipeline_instruction(self):
         instruction = rest_communication.get_document(
-            'projects', match={'project_id': self.project_id}
+            'projects', where={'project_id': self.project_id}
         ).get('sample_pipeline')
 
         if not instruction:
@@ -481,7 +481,7 @@ class SampleDataset(Dataset):
 
     def _pipeline_instruction(self):
         instruction = rest_communication.get_document(
-            'projects', match={'project_id': self.project_id}
+            'projects', where={'project_id': self.project_id}
         ).get('sample_pipeline')
 
         if not instruction:

--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -225,6 +225,10 @@ class NoCommunicationDataset(Dataset):
 
 class NoCommuncationSampleDataset(NoCommunicationDataset):
 
+    def __init__(self, name):
+        super().__init__(name)
+        self._run_elements = None
+
     @property
     def run_elements(self):
         if self._run_elements is None:

--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -223,6 +223,31 @@ class NoCommunicationDataset(Dataset):
         return None
 
 
+class NoCommuncationSampleDataset(NoCommunicationDataset):
+
+    @property
+    def run_elements(self):
+        if self._run_elements is None:
+            self._run_elements = rest_communication.get_documents(
+                'run_elements', where={'sample_id': self.name, 'useable': 'yes'}
+            )
+        return self._run_elements
+
+    @property
+    def project_id(self):
+        return self.run_elements[0]['project_id']
+
+    def _pipeline_instruction(self):
+        instruction = rest_communication.get_document(
+            'projects', match={'project_id': self.project_id}
+        ).get('sample_pipeline')
+
+        if not instruction:
+            raise AnalysisDriverError('No instruction set in project %s' % self.project_id)
+
+        return instruction
+
+
 class RunDataset(Dataset):
     type = 'run'
     endpoint = 'runs'

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -9,7 +9,7 @@ path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from analysis_driver import quality_control as qc
 from analysis_driver.config import default as cfg, load_config
 from analysis_driver.exceptions import AnalysisDriverError
-from analysis_driver.dataset import NoCommunicationDataset, RunDataset
+from analysis_driver.dataset import NoCommunicationDataset, RunDataset, NoCommuncationSampleDataset
 from analysis_driver.util.bash_commands import rsync_from_to
 from analysis_driver.reader.demultiplexing_parsers import parse_fastqscreen_file
 
@@ -76,6 +76,8 @@ def _parse_args():
 def run_genotype_validation(dataset, args):
     # Get the sample specific config
     cfg.merge(cfg['sample'])
+    dataset = NoCommuncationSampleDataset(dataset.name)
+    dataset.resolve_pipeline_and_toolset()
     os.makedirs(os.path.join(cfg['jobs_dir'], dataset.name), exist_ok=True)
 
     sample_output_dir = os.path.join(cfg['output_dir'], args.project_id, dataset.name)


### PR DESCRIPTION
run_qc cannot run due to not calling resolve pipeline - this PR adds NoCommunicationSampleDataset to allow to get the pipeline and toolset.