### PR TITLE
Fix for sample's default values scanner forcing data threshold

### DIFF
--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -482,10 +482,12 @@ class SampleDataset(Dataset):
         y = self.sample.get('aggregated', {}).get('clean_yield_in_gb')
         if y:
             return int(y * 1000000000)
+        else:
+            return 0
 
     @property
     def pc_q30(self):
-        return self.sample.get('aggregated', {}).get('clean_pc_q30')
+        return self.sample.get('aggregated', {}).get('clean_pc_q30') or 0
 
     @property
     def data_threshold(self):

--- a/analysis_driver/dataset_scanner.py
+++ b/analysis_driver/dataset_scanner.py
@@ -48,18 +48,18 @@ class DatasetScanner(AppLogger):
             statuses.remove(DATASET_NEW)
             statuses.append(None)
         if len(statuses) > 1:
-            match = {'$or': [{'proc_status': status} for status in statuses]}
+            where = {'$or': [{'aggregated.most_recent_proc.status': status} for status in statuses]}
         else:
-            match = {'proc_status': statuses[0]}
+            where = {'aggregated.most_recent_proc.status': statuses[0]}
         return [
-            d for d in get_documents(self.endpoint, match=match, paginate=False, quiet=True)
+            d for d in get_documents(self.endpoint, where=where, all_pages=True, quiet=True, max_results=100)
             if d[self.item_id] not in self._triggerignore
         ]
 
     def _get_datasets_for_statuses(self, statuses):
         self.debug('Creating Datasets for status %s', ', '.join(statuses))
         return [
-            self.get_dataset(d[self.item_id], d.get('most_recent_proc'))
+            self.get_dataset(d[self.item_id], d.get('aggregated', {}).get('most_recent_proc'))
             for d in self._get_dataset_records_for_statuses(statuses)
         ]
 
@@ -91,7 +91,7 @@ class DatasetScanner(AppLogger):
 
 
 class RunScanner(DatasetScanner):
-    endpoint = 'aggregate/all_runs'
+    endpoint = 'runs'
     item_id = 'run_id'
     expected_bcl_subdirs = ('RunInfo.xml', 'Data')
 
@@ -129,33 +129,15 @@ class RunScanner(DatasetScanner):
 
 
 class SampleScanner(DatasetScanner):
-    endpoint = 'aggregate/samples'
+    endpoint = 'samples'
     item_id = 'sample_id'
 
-    def get_dataset(self, name, most_recent_proc=None, data_threshold=None):
-        return SampleDataset(name, most_recent_proc, data_threshold)
-
-    def _get_datasets_for_statuses(self, statuses):
-        self.debug('Creating Datasets for status %s', ', '.join(statuses))
-        datasets = {}
-        for r in self._get_dataset_records_for_statuses(statuses):
-            datasets[r[self.item_id]] = {'record': r}
-
-        if datasets:
-            self.debug('Querying Lims for %s samples', len(datasets))
-            for sample in get_list_of_samples(list(datasets)):
-                req_yield = sample.udf.get('Yield for Quoted Coverage (Gb)') * 1000000000
-                datasets[sanitize_user_id(sample.name)]['threshold'] = req_yield
-            self.debug('Lims query complete')
-
-        return [
-            self.get_dataset(k, v['record'].get('most_recent_proc'), v.get('threshold'))
-            for k, v in datasets.items()
-        ]
+    def get_dataset(self, name, most_recent_proc=None):
+        return SampleDataset(name, most_recent_proc)
 
 
 class ProjectScanner(DatasetScanner):
-    endpoint = 'aggregate/projects'
+    endpoint = 'projects'
     item_id = 'project_id'
 
     def get_dataset(self, name, most_recent_proc=None):

--- a/tests/test_dataset_scanner.py
+++ b/tests/test_dataset_scanner.py
@@ -134,10 +134,11 @@ class TestSampleScanner(TestScanner):
     def test_get_dataset_records_for_statuses(self, mocked_get):
         assert self.scanner._get_dataset_records_for_statuses([DATASET_NEW]) == [{'sample_id': 'a_sample_id'}]
         mocked_get.assert_any_call(
-            'aggregate/samples',
-            match={'proc_status': None},
-            paginate=False,
-            quiet=True
+            'samples',
+            where={'aggregated.most_recent_proc.status': None},
+            all_pages=True,
+            quiet=True,
+            max_results=100
         )
 
     @patched_get([{'sample_id': 'a_sample_id'}])
@@ -149,8 +150,13 @@ class TestSampleScanner(TestScanner):
         with patched_list_samples:
             d = self.scanner._get_datasets_for_statuses([DATASET_NEW])[0]
         assert d.name == 'a_sample_id'
-        assert d._data_threshold == 1000000000
-        mocked_get.assert_any_call('aggregate/samples', match={'proc_status': None}, paginate=False, quiet=True)
+        mocked_get.assert_any_call(
+            'samples',
+            where={'aggregated.most_recent_proc.status': None},
+            all_pages=True,
+            quiet=True,
+            max_results=100
+        )
 
     def test_scan_datasets(self):
         fake_datasets = {DATASET_NEW: []}


### PR DESCRIPTION
This PR sets default values for `pc_q30` and `_amount_data` in `SampleDataset` which superseded #314 
It also fixes #315 by removing the query for data threshold in SampleScanner.
 