### PR TITLE
force the version of interop library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pip>=9.0.1
 scipy
 numpy>=1.12.1
 -f https://github.com/Illumina/interop/releases/tag/v1.0.25
-interop
+interop==1.0.25


### PR DESCRIPTION
Fix the build issue we've been having.
pip was downloading first from pypi https://pypi.python.org/pypi/interop/1.1.3
Ignoring the tag page in the requirement file making it download the latest version.
This also mean that our code fails with the lastest version of interop but that is another issue.
fixes #320 
