### PR TITLE
Remove phix

### DIFF
--- a/analysis_driver/pipelines/demultiplexing.py
+++ b/analysis_driver/pipelines/demultiplexing.py
@@ -107,7 +107,8 @@ class PhixDetection(DemultiplexingStage):
             job_name='phix_detection',
             working_dir=self.job_dir,
             cpus=16,
-            mem=10
+            mem=10,
+            log_commands=False
         ).join()
         if exit_status == 0 :
             # Send the results of BCL2fastq to the rest API

--- a/analysis_driver/report_generation/run_crawler.py
+++ b/analysis_driver/report_generation/run_crawler.py
@@ -160,6 +160,9 @@ class RunCrawler(Crawler):
             if len(read_name_files) == 1:
                 with open(read_name_files[0]) as open_file:
                     barcode_info[ELEMENT_NB_READS_PHIX] = sum(1 for _ in open_file)
+            elif barcode_info[ELEMENT_NB_READS_PASS_FILTER] == 0:
+                self.info('No reads for %s, Not expecting Phix filtered file', run_element_id)
+                continue
             else:
                 raise PipelineError('No Phix read_name file found in %s for %s' % (run_dir, run_element_id))
 

--- a/analysis_driver/report_generation/run_crawler.py
+++ b/analysis_driver/report_generation/run_crawler.py
@@ -157,8 +157,11 @@ class RunCrawler(Crawler):
                     barcode_info[ELEMENT_SAMPLE_INTERNAL_ID],
                     '*_S*_L00%s_phix_read_name.list' % barcode_info[ELEMENT_LANE]
                 )
-            with open(read_name_files) as open_file:
-                barcode_info[ELEMENT_NB_READS_PHIX] = sum(1 for _ in open_file)
+            if len(read_name_files) == 1:
+                with open(read_name_files[0]) as open_file:
+                    barcode_info[ELEMENT_NB_READS_PHIX] = sum(1 for _ in open_file)
+            else:
+                raise PipelineError('No Phix read_name file found in %s for %s' % (run_dir, run_element_id))
 
     def _populate_barcode_info_from_seqtk_fqchk_files(self, run_dir):
         for run_element_id in self.barcodes_info:

--- a/analysis_driver/report_generation/run_crawler.py
+++ b/analysis_driver/report_generation/run_crawler.py
@@ -162,9 +162,9 @@ class RunCrawler(Crawler):
                     barcode_info[ELEMENT_NB_READS_PHIX] = sum(1 for _ in open_file)
             elif barcode_info[ELEMENT_NB_READS_PASS_FILTER] == 0:
                 self.info('No reads for %s, Not expecting Phix filtered file', run_element_id)
-                continue
             else:
-                raise PipelineError('No Phix read_name file found in %s for %s' % (run_dir, run_element_id))
+                # TODO: Not mandatory for now as there will be lots of old runs without it
+                self.warning('No Phix read_name file found in %s for %s' % (run_dir, run_element_id))
 
     def _populate_barcode_info_from_seqtk_fqchk_files(self, run_dir):
         for run_element_id in self.barcodes_info:

--- a/analysis_driver/report_generation/run_crawler.py
+++ b/analysis_driver/report_generation/run_crawler.py
@@ -24,6 +24,7 @@ class RunCrawler(Crawler):
                 self._populate_barcode_info_from_conversion_file(run_dir)
                 self._populate_barcode_info_from_adapter_file(run_dir)
                 self._populate_barcode_info_from_well_dup(run_dir)
+                self._populate_barcode_info_from_phix_read_names(run_dir)
             if stage >= self.STAGE_FILTER:
                 self._populate_barcode_info_from_fastq_filterer_files(run_dir)
                 self._populate_barcode_info_from_seqtk_fqchk_files(run_dir)
@@ -141,6 +142,23 @@ class RunCrawler(Crawler):
             for run_element_id in self.barcodes_info:
                 self.barcodes_info[run_element_id][ELEMENT_ADAPTER_TRIM_R1] = run_element_adapters_trimmed[run_element_id]['read_1_trimmed_bases']
                 self.barcodes_info[run_element_id][ELEMENT_ADAPTER_TRIM_R2] = run_element_adapters_trimmed[run_element_id]['read_2_trimmed_bases']
+
+    def _populate_barcode_info_from_phix_read_names(self, run_dir):
+        for run_element_id in self.barcodes_info:
+            barcode_info = self.barcodes_info.get(run_element_id)
+            if ELEMENT_BARCODE in barcode_info and barcode_info[ELEMENT_BARCODE] == 'unknown':
+                read_name_files = util.find_files(
+                    run_dir, 'Undetermined_S0_L00%s_phix_read_name.list' % barcode_info[ELEMENT_LANE]
+                )
+            else:
+                read_name_files = util.find_files(
+                    run_dir,
+                    barcode_info[ELEMENT_PROJECT_ID],
+                    barcode_info[ELEMENT_SAMPLE_INTERNAL_ID],
+                    '*_S*_L00%s_phix_read_name.list' % barcode_info[ELEMENT_LANE]
+                )
+            with open(read_name_files) as open_file:
+                barcode_info[ELEMENT_NB_READS_PHIX] = sum(1 for _ in open_file)
 
     def _populate_barcode_info_from_seqtk_fqchk_files(self, run_dir):
         for run_element_id in self.barcodes_info:

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -53,7 +53,7 @@ def fq_filt_prelim_cmd():
         'shift 10',
         'mkfifo $fifo_1', 'mkfifo $fifo_2',
         '{ff} --i1 $i1 --i2 $i2 --o1 $fifo_1 --o2 $fifo_2 --threshold {threshold} '  # no comma means concatenation
-        '--stats_file $stats_file --read_name $read_name_file --f1 $out_phix1 --f2 $out_phix2 $* &',
+        '--stats_file $stats_file --remove_reads $read_name_file --f1 $out_phix1 --f2 $out_phix2 $* &',
         'fq_filt_pid=$!',
         '{pigz} -c -p {pzt} $fifo_1 > $o1 &',
         'pigz_r1_pid=$!',

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -49,7 +49,7 @@ def fq_filt_prelim_cmd():
     cmd = (
         'function run_filterer {{',  # double up { and } to escape them for str.format()
         'strategy=$1', 'i1=$2', 'i2=$3', 'o1=$4', 'o2=$5', 'fifo_1=$6', 'fifo_2=$7', 'stats_file=$8', 'read_name_file=$9' ,
-        'out_phix1=$10', 'out_phix2=$11',
+        'out_phix1=${{10}}', 'out_phix2=${{11}}',
         'shift 10',
         'mkfifo $fifo_1', 'mkfifo $fifo_2',
         '{ff} --i1 $i1 --i2 $i2 --o1 $fifo_1 --o2 $fifo_2 --threshold {threshold} '  # no comma means concatenation
@@ -108,12 +108,12 @@ def fastq_filterer(fastq_file_pair, read_name_file, tiles_to_filter=None, trim_r
     i1, i2 = sorted(fastq_file_pair)
 
     base_1 = i1.replace('.fastq.gz', '')
-    phix1 = base_1 + '_phix.fastq'
+    phix1 = base_1 + '.fastq_discarded'
     fifo_1 = base_1 + '_filtered.fastq'
     o1 = fifo_1 + '.gz'
 
     base_2 = i2.replace('.fastq.gz', '')
-    phix2 = base_2 + '_phix.fastq'
+    phix2 = base_2 + '.fastq_discarded'  # add suffix to avoid collision with find_fastq functions
     fifo_2 = base_2 + '_filtered.fastq'
     o2 = fifo_2 + '.gz'
 

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -53,7 +53,7 @@ def fq_filt_prelim_cmd():
         'shift 10',
         'mkfifo $fifo_1', 'mkfifo $fifo_2',
         '{ff} --i1 $i1 --i2 $i2 --o1 $fifo_1 --o2 $fifo_2 --threshold {threshold} '  # no comma means concatenation
-        '--stats_file $stats_file --read_name $read_name_file --out_phix1 out_phix1 --out_phix2 out_phix2 $* &',
+        '--stats_file $stats_file --read_name $read_name_file --f1 $out_phix1 --f2 $out_phix2 $* &',
         'fq_filt_pid=$!',
         '{pigz} -c -p {pzt} $fifo_1 > $o1 &',
         'pigz_r1_pid=$!',

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -68,9 +68,9 @@ def fq_filt_prelim_cmd():
         'wait $pigz_r2_pid',
         'exit_status=$[$exit_status + $?]',
 
-        '{pigz} -c -p {pzt} $out_phix1 &',
+        '{pigz} -p {pzt} $out_phix1 &',
         'pigz_phix1_pid=$!',
-        '{pigz} -c -p {pzt} $out_phix2 &',
+        '{pigz} -p {pzt} $out_phix2 &',
         'pigz_phix2_pid=$!',
 
         'wait $pigz_phix1_pid',

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -160,7 +160,7 @@ def bwa_mem_samblaster(fastq_pair, reference, expected_output_bam, read_group=No
 
 def bwa_mem_phix(fastq1, read_name_list, thread=16):
     command_bwa = '%s mem -t %s %s %s' % (toolset['bwa'], thread, cfg.query('genomes', 'phix174', 'fasta'), fastq1)
-    command_samtools = '%s -F 4  | sort -u > %s' % (toolset['samtools'], read_name_list)
+    command_samtools = '%s view -F 4 | cut -f 1 | sort -u > %s' % (toolset['samtools'], read_name_list)
     cmd = 'set -o pipefail; ' + ' | '.join([command_bwa, command_samtools])
     app_logger.debug('Writing: ' + cmd)
     return cmd

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -68,14 +68,14 @@ def fq_filt_prelim_cmd():
         'wait $pigz_r2_pid',
         'exit_status=$[$exit_status + $?]',
 
-        '{pigz} -c -p {pzt} $out_phix1 &'
+        '{pigz} -c -p {pzt} $out_phix1 &',
         'pigz_phix1_pid=$!',
-        '{pigz} -c -p {pzt} $out_phix2 &'
+        '{pigz} -c -p {pzt} $out_phix2 &',
         'pigz_phix2_pid=$!',
 
-        'wait pigz_phix1_pid',
+        'wait $pigz_phix1_pid',
         'exit_status=$[$exit_status + $?]',
-        'wait pigz_phix2_pid',
+        'wait $pigz_phix2_pid',
         'exit_status=$[$exit_status + $?]',
 
         'rm $fifo_1 $fifo_2',

--- a/bin/remove_phix.py
+++ b/bin/remove_phix.py
@@ -57,14 +57,15 @@ def remove_phix(sample_id):
     # bwa alignment
     cmds = []
     for fqs in fastq_pairs:
-        read_name_list = fqs[0][:-len('_R1_001.fastq.gz')] + 'phix_read_name.list'
+        read_name_list = fqs[0][:-len('_R1_001.fastq.gz')] + '_phix_read_name.list'
         cmds.append(bash_commands.bwa_mem_phix(fqs[0], read_name_list))
     bwa_status = executor.execute(
         *cmds,
         job_name='phix_detection',
         working_dir=job_dir,
         cpus=16,
-        mem=10
+        mem=10,
+        log_commands=False
     ).join()
 
     if bwa_status != 0:
@@ -73,7 +74,7 @@ def remove_phix(sample_id):
     # fastq filterer
     cmds = []
     for fqs in fastq_pairs:
-        read_name_list = fqs[0][:-len('_R1_001.fastq.gz')] + 'phix_read_name.list'
+        read_name_list = fqs[0][:-len('_R1_001.fastq.gz')] + '_phix_read_name.list'
         cmds.append(bash_commands.fastq_filterer(fqs, read_name_list))
 
     filterer_status = executor.execute(

--- a/bin/remove_phix.py
+++ b/bin/remove_phix.py
@@ -2,7 +2,7 @@ import os
 import logging
 import argparse
 import sys
-from egcg_core import executor, util, rest_communication
+from egcg_core import executor, util, rest_communication, archive_management
 from egcg_core.app_logging import logging_default as log_cfg
 from egcg_core import constants as c
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -134,6 +134,9 @@ def remove_phix(sample_id):
         run_dir = os.path.join(cfg['input_dir'], run_id)
         crawler = RunCrawler(rd, run_dir=run_dir, stage=RunCrawler.STAGE_MAPPING)
         crawler.send_data()
+
+        # Ensure that the tape is up to date
+        archive_management.archive_directory(run_dir)
 
 
 if __name__ == '__main__':

--- a/bin/remove_phix.py
+++ b/bin/remove_phix.py
@@ -8,9 +8,8 @@ from egcg_core import executor, util, rest_communication
 from egcg_core.app_logging import logging_default as log_cfg
 from egcg_core import constants as c
 
-from analysis_driver.util import bash_commands
-
 path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from analysis_driver.util import bash_commands
 from analysis_driver.config import default as cfg, load_config
 from analysis_driver.exceptions import PipelineError
 from analysis_driver.dataset import NoCommuncationSampleDataset

--- a/bin/remove_phix.py
+++ b/bin/remove_phix.py
@@ -1,21 +1,19 @@
 import os
 import logging
 import argparse
-from sys import path
-
 import sys
 from egcg_core import executor, util, rest_communication
 from egcg_core.app_logging import logging_default as log_cfg
 from egcg_core import constants as c
-
-path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from analysis_driver.util import bash_commands
 from analysis_driver.config import default as cfg, load_config
 from analysis_driver.exceptions import PipelineError
-from analysis_driver.dataset import NoCommuncationSampleDataset, RunDataset
+from analysis_driver.dataset import RunDataset
 from analysis_driver.report_generation import RunCrawler
 
 app_logger = log_cfg.get_logger('Remove_phix')
+
 
 def main():
     args = _parse_args()
@@ -34,14 +32,13 @@ def _parse_args():
 def remove_phix(sample_id):
     # Get the sample specific config
     cfg.merge(cfg['sample'])
-    dataset = NoCommuncationSampleDataset(sample_id)
-    rundataset = RunDataset(dataset.run_elements[0].get(c.ELEMENT_RUN_NAME))
+    run_elements = rest_communication.get_documents('run_elements', where={'sample_id': sample_id})
+    rundataset = RunDataset(run_elements[0].get(c.ELEMENT_RUN_NAME))
 
     rundataset.resolve_pipeline_and_toolset()
-    job_dir = os.path.join(cfg['jobs_dir'], 'manual_' + dataset.name)
+    job_dir = os.path.join(cfg['jobs_dir'], 'manual_' + sample_id)
     os.makedirs(job_dir, exist_ok=True)
 
-    run_elements = rest_communication.get_documents('run_elements', where={'sample_id': sample_id})
     # Find all fastq files
     fastq_pairs = []
     for run_element in run_elements:
@@ -133,7 +130,7 @@ def remove_phix(sample_id):
 
     for run_id in set(r.get(c.ELEMENT_RUN_NAME) for r in run_elements):
         rd = RunDataset(run_id)
-        run_dir = os.path.join(cfg['input_dir'], run_element.get(c.ELEMENT_RUN_NAME))
+        run_dir = os.path.join(cfg['input_dir'], run_id)
         crawler = RunCrawler(rd, run_dir=run_dir, stage=RunCrawler.STAGE_MAPPING)
         crawler.send_data()
 

--- a/bin/remove_phix.py
+++ b/bin/remove_phix.py
@@ -1,0 +1,132 @@
+import os
+import logging
+import argparse
+from sys import path
+
+import sys
+from egcg_core import executor, util, rest_communication
+from egcg_core.app_logging import logging_default as log_cfg
+from egcg_core import constants as c
+
+from analysis_driver.util import bash_commands
+
+path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from analysis_driver.config import default as cfg, load_config
+from analysis_driver.exceptions import PipelineError
+from analysis_driver.dataset import NoCommuncationSampleDataset
+
+
+def main():
+    args = _parse_args()
+    load_config()
+    log_cfg.default_level = logging.DEBUG
+    log_cfg.add_stdout_handler(logging.DEBUG)
+    remove_phix(args.sample_id)
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--sample_id', required=True)
+    return parser.parse_args()
+
+
+def remove_phix(sample_id):
+    # Get the sample specific config
+    cfg.merge(cfg['sample'])
+    dataset = NoCommuncationSampleDataset(sample_id)
+    dataset.resolve_pipeline_and_toolset()
+    job_dir = os.path.join(cfg['jobs_dir'], 'manual_' + dataset.name)
+    os.makedirs(job_dir, exist_ok=True)
+
+    run_elements = rest_communication.get_documents('run_elements', where={'sample_id': sample_id})
+    # Find all fastq files
+    fastq_pairs = []
+    for run_element in run_elements:
+        run_dir = os.path.join(cfg['input_dir'], run_element.get(c.ELEMENT_RUN_NAME))
+        fqs = util.find_fastqs(
+            run_dir,
+            run_element.get(c.ELEMENT_PROJECT_ID),
+            run_element.get(c.ELEMENT_SAMPLE_INTERNAL_ID),
+            run_element.get(c.ELEMENT_LANE)
+        )
+        fqs.sort()
+        assert len(fqs) == 2
+        fastq_pairs.append(fqs)
+
+    # bwa alignment
+    cmds = []
+    for fqs in fastq_pairs:
+        read_name_list = fqs[0][:-len('_R1_001.fastq.gz')] + 'phix_read_name.list'
+        cmds.append(bash_commands.bwa_mem_phix(fqs[0], read_name_list))
+    bwa_status = executor.execute(
+        *cmds,
+        job_name='phix_detection',
+        working_dir=job_dir,
+        cpus=16,
+        mem=10
+    ).join()
+
+    if bwa_status != 0:
+        raise PipelineError('Bwa execution for sample %s failed with status %s' % (sample_id, bwa_status))
+
+    # fastq filterer
+    cmds = []
+    for fqs in fastq_pairs:
+        read_name_list = fqs[0][:-len('_R1_001.fastq.gz')] + 'phix_read_name.list'
+        cmds.append(bash_commands.fastq_filterer(fqs, read_name_list))
+
+    filterer_status = executor.execute(
+        *cmds,
+        prelim_cmds=[bash_commands.fq_filt_prelim_cmd()],
+        job_name='fastq_filterer',
+        working_dir=job_dir,
+        cpus=18,
+        mem=10
+    ).join()
+    if filterer_status != 0:
+        raise PipelineError('Fastq_filterer execution for sample %s failed with status %s' % (sample_id, filterer_status))
+
+    # fastqc
+    fastqc_exec = executor.execute(
+        *[bash_commands.fastqc(f) for f in [fq for fqs in fastq_pairs for fq in fqs]],
+        job_name='fastqc',
+        working_dir=job_dir,
+        cpus=1,
+        mem=2
+    )
+
+    # Seqtk fqchk
+    seqtk_exec = executor.execute(
+        *[bash_commands.seqtk_fqchk(f) for f in [fq for fqs in fastq_pairs for fq in fqs]],
+        job_name='fqchk',
+        working_dir=job_dir,
+        cpus=1,
+        mem=2,
+        log_commands=False
+    )
+
+    # md5 calculation
+    md5_exec = executor.execute(
+        *[bash_commands.md5sum(f) for f in [fq for fqs in fastq_pairs for fq in fqs]],
+        job_name='md5sum',
+        working_dir=job_dir,
+        cpus=1,
+        mem=2,
+        log_commands=False
+    )
+
+    fastqc_status = fastqc_exec.join()
+    if fastqc_status != 0:
+        raise PipelineError('Fastqc execution for sample %s failed with status %s' % (sample_id, fastqc_status))
+
+    seqtk_status = seqtk_exec.join()
+    if seqtk_status != 0:
+        raise PipelineError('Seqtk execution for sample %s failed with status %s' % (sample_id, seqtk_status))
+
+    md5_status = md5_exec.join()
+    if md5_status != 0:
+        raise PipelineError('Md5 execution for sample %s failed with status %s' % (sample_id, md5_status))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/etc/example_analysisdriver.yaml
+++ b/etc/example_analysisdriver.yaml
@@ -103,6 +103,8 @@ default:
         fasta: /path/to/genome.fa
         dbsnp: /path/to/dbsnp.vcf.gz
         known_indels: /path/to/known/indels
+      phix174:
+        fasta: /path/to/phix.fa
 
     clarity:
         baseuri: 'https://clarity.co.uk'

--- a/etc/tool_versioning.yaml
+++ b/etc/tool_versioning.yaml
@@ -12,7 +12,7 @@ toolsets:
                 version_cmd: grep_toolname
 
             fastq_filterer:
-                version: 0.3.1
+                version: 0.4
                 version_cmd: '{executable} --version'
 
             fastqc:

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -220,7 +220,7 @@ class IntegrationTest(TestCase):
                     ),
                     integration_cfg['demultiplexing']['lane_qc']
                 )
-            self.expect_stage_data('setup', 'wellduplicates', 'bcl2fastq', 'fastqfilter', 'seqtkfqchk',
+            self.expect_stage_data('setup', 'wellduplicates', 'bcl2fastq', 'PhixDetection', 'fastqfilter', 'seqtkfqchk',
                                    'md5sum', 'fastqc', 'integritycheck', 'qcoutput', 'dataoutput', 'cleanup',
                                    'samtoolsdepthmulti', 'picardinsertsizemulti', 'qcoutput2', 'runreview',
                                    'picardmarkduplicatemulti', 'samtoolsstatsmulti', 'bwaalignmulti')

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -220,7 +220,7 @@ class IntegrationTest(TestCase):
                     ),
                     integration_cfg['demultiplexing']['lane_qc']
                 )
-            self.expect_stage_data('setup', 'wellduplicates', 'bcl2fastq', 'PhixDetection', 'fastqfilter', 'seqtkfqchk',
+            self.expect_stage_data('setup', 'wellduplicates', 'bcl2fastq', 'phixdetection', 'fastqfilter', 'seqtkfqchk',
                                    'md5sum', 'fastqc', 'integritycheck', 'qcoutput', 'dataoutput', 'cleanup',
                                    'samtoolsdepthmulti', 'picardinsertsizemulti', 'qcoutput2', 'runreview',
                                    'picardmarkduplicatemulti', 'samtoolsstatsmulti', 'bwaalignmulti')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-EGCG-Core==0.8.1
+EGCG-Core==0.8.2
 luigi==2.5.0
 ete3==3.0.0b35
 pandas<0.21

--- a/tests/assets/test_crawlers/expected_run_crawler_data.json
+++ b/tests/assets/test_crawlers/expected_run_crawler_data.json
@@ -79,7 +79,8 @@
             "lane_pc_optical_dups": 6.716,
             "tiles_filtered": "1102,2202",
             "trim_r1": "14",
-            "trim_r2": "16"
+            "trim_r2": "16",
+            "phix_reads": 3
         },
         "a_run_id_2_unknown": {
             "sample_id": "Undetermined",
@@ -106,7 +107,8 @@
             "lane_pc_optical_dups": 4.492,
             "tiles_filtered": "1102,2202",
             "trim_r1": "14",
-            "trim_r2": "16"
+            "trim_r2": "16",
+            "phix_reads": 3
         },
         "a_run_id_2_ATTACTCG": {
             "sample_id": "10015AT0001",
@@ -133,7 +135,8 @@
             "lane_pc_optical_dups": 4.492,
             "tiles_filtered": "1102,2202",
             "trim_r1": "14",
-            "trim_r2": "16"
+            "trim_r2": "16",
+            "phix_reads": 3
         },
         "a_run_id_1_TCCGGAGA": {
             "sample_id": "10015AT0002",
@@ -160,7 +163,8 @@
             "lane_pc_optical_dups": 6.716,
             "tiles_filtered": "1102,2202",
             "trim_r1": "14",
-            "trim_r2": "16"
+            "trim_r2": "16",
+            "phix_reads": 3
         },
         "a_run_id_2_TCCGGAGA": {
             "sample_id": "10015AT0002",
@@ -187,7 +191,8 @@
             "lane_pc_optical_dups": 4.492,
             "tiles_filtered": "1102,2202",
             "trim_r1": "14",
-            "trim_r2": "16"
+            "trim_r2": "16",
+            "phix_reads": 3
         },
         "a_run_id_1_ATTACTCG": {
             "sample_id": "10015AT0001",
@@ -215,6 +220,7 @@
             "tiles_filtered": "1102,2202",
             "trim_r1": "14",
             "trim_r2": "16",
+            "phix_reads": 3,
             "mapping_metrics": {
                 "bam_file_reads": 1074198,
                 "duplicate_reads": 156823,

--- a/tests/assets/test_crawlers/test_run_dir/10015AT/10015AT0001/a_run_id_1_S0_L001_phix_read_name.list
+++ b/tests/assets/test_crawlers/test_run_dir/10015AT/10015AT0001/a_run_id_1_S0_L001_phix_read_name.list
@@ -1,0 +1,3 @@
+read1
+read4
+read6

--- a/tests/assets/test_crawlers/test_run_dir/10015AT/10015AT0001/a_run_id_2_S0_L002_phix_read_name.list
+++ b/tests/assets/test_crawlers/test_run_dir/10015AT/10015AT0001/a_run_id_2_S0_L002_phix_read_name.list
@@ -1,0 +1,3 @@
+read1
+read4
+read6

--- a/tests/assets/test_crawlers/test_run_dir/10015AT/10015AT0002/a_run_id_1_S0_L001_phix_read_name.list
+++ b/tests/assets/test_crawlers/test_run_dir/10015AT/10015AT0002/a_run_id_1_S0_L001_phix_read_name.list
@@ -1,0 +1,3 @@
+read1
+read4
+read6

--- a/tests/assets/test_crawlers/test_run_dir/10015AT/10015AT0002/a_run_id_2_S0_L002_phix_read_name.list
+++ b/tests/assets/test_crawlers/test_run_dir/10015AT/10015AT0002/a_run_id_2_S0_L002_phix_read_name.list
@@ -1,0 +1,3 @@
+read1
+read4
+read6

--- a/tests/assets/test_crawlers/test_run_dir/Undetermined_S0_L001_phix_read_name.list
+++ b/tests/assets/test_crawlers/test_run_dir/Undetermined_S0_L001_phix_read_name.list
@@ -1,0 +1,3 @@
+read1
+read4
+read6

--- a/tests/assets/test_crawlers/test_run_dir/Undetermined_S0_L002_phix_read_name.list
+++ b/tests/assets/test_crawlers/test_run_dir/Undetermined_S0_L002_phix_read_name.list
@@ -1,0 +1,3 @@
+read1
+read4
+read6

--- a/tests/test_bash_commands.py
+++ b/tests/test_bash_commands.py
@@ -130,12 +130,12 @@ def test_fastq_filterer():
     assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'), 'RE_phix_read_name.txt') == (
         'run_filterer in_place RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
         'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats '
-        'RE_phix_read_name.txt RE_R1_001_phix.fastq RE_R2_001_phix.fastq'
+        'RE_phix_read_name.txt RE_R1_001.fastq_discarded RE_R2_001.fastq_discarded'
     )
     assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'), 'RE_phix_read_name.txt', trim_r1=149) == (
         'run_filterer keep_originals RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
         'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats '
-        'RE_phix_read_name.txt RE_R1_001_phix.fastq RE_R2_001_phix.fastq --trim_r1 149'
+        'RE_phix_read_name.txt RE_R1_001.fastq_discarded RE_R2_001.fastq_discarded --trim_r1 149'
     )
 
 

--- a/tests/test_bash_commands.py
+++ b/tests/test_bash_commands.py
@@ -127,14 +127,15 @@ def test_seqtk_fqchk():
 
 
 def test_fastq_filterer():
-    assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz')) == (
+    assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'), 'RE_phix_read_name.txt') == (
         'run_filterer in_place RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
-        'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats'
+        'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats '
+        'RE_phix_read_name.txt RE_R1_001_phix.fastq RE_R2_001_phix.fastq'
     )
-    assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'), trim_r1=149) == (
+    assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'), 'RE_phix_read_name.txt', trim_r1=149) == (
         'run_filterer keep_originals RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
-        'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats'
-        ' --trim_r1 149'
+        'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats '
+        'RE_phix_read_name.txt RE_R1_001_phix.fastq RE_R2_001_phix.fastq --trim_r1 149'
     )
 
 

--- a/tests/test_pipelines/test_demultiplexing.py
+++ b/tests/test_pipelines/test_demultiplexing.py
@@ -31,8 +31,8 @@ class TestPhixDetection(TestAnalysisDriver):
             f._run()
 
             expected_call = (
-            'set -o pipefail; path/to/bwa mem -t 16 /path/to/phix.fa L1_R1_001.fastq.gz | path/to/samtools -F 4  |'
-            ' sort -u > L1_phix_read_name.list'
+            'set -o pipefail; path/to/bwa mem -t 16 /path/to/phix.fa L1_R1_001.fastq.gz | path/to/samtools view -F 4 |'
+            ' cut -f 1 | sort -u > L1_phix_read_name.list'
             )
             assert expected_call == pexecute.call_args[0][0]
             prun_crawler.assert_called_with(dataset, run_dir='tests/assets/jobs/test/fastq',

--- a/tests/test_pipelines/test_demultiplexing.py
+++ b/tests/test_pipelines/test_demultiplexing.py
@@ -73,17 +73,17 @@ class TestFastqFilter(TestAnalysisDriver):
             expected_call_l2 = (
                 'run_filterer in_place L2_R1_001.fastq.gz L2_R2_001.fastq.gz L2_R1_001_filtered.fastq.gz '
                 'L2_R2_001_filtered.fastq.gz L2_R1_001_filtered.fastq L2_R2_001_filtered.fastq L2_fastqfilterer.stats '
-                'L2_phix_read_name.list L2_R1_001_phix.fastq L2_R2_001_phix.fastq'
+                'L2_phix_read_name.list L2_R1_001.fastq_discarded L2_R2_001.fastq_discarded'
             )
             expected_call_l3 = (
                 'run_filterer keep_originals L3_R1_001.fastq.gz L3_R2_001.fastq.gz L3_R1_001_filtered.fastq.gz '
                 'L3_R2_001_filtered.fastq.gz L3_R1_001_filtered.fastq L3_R2_001_filtered.fastq L3_fastqfilterer.stats '
-                'L3_phix_read_name.list L3_R1_001_phix.fastq L3_R2_001_phix.fastq --remove_tiles 1101'
+                'L3_phix_read_name.list L3_R1_001.fastq_discarded L3_R2_001.fastq_discarded --remove_tiles 1101'
             )
             expected_call_l4 = (
                 'run_filterer keep_originals L4_R1_001.fastq.gz L4_R2_001.fastq.gz L4_R1_001_filtered.fastq.gz '
                 'L4_R2_001_filtered.fastq.gz L4_R1_001_filtered.fastq L4_R2_001_filtered.fastq L4_fastqfilterer.stats '
-                'L4_phix_read_name.list L4_R1_001_phix.fastq L4_R2_001_phix.fastq --trim_r2 147'
+                'L4_phix_read_name.list L4_R1_001.fastq_discarded L4_R2_001.fastq_discarded --trim_r2 147'
             )
             assert expected_call_l2 == pexecute.call_args[0][1]
             assert expected_call_l3 == pexecute.call_args[0][2]


### PR DESCRIPTION
This PR will add a new step in demultiplexing pipeline that will align read1 to the Phix genome. get the reads that align and extract them from the fastq file using fastqfilterer's new feature.
fixes #329 
It also add a new script that can take already generated fastq file and extract PhiX reads using the same procedure. The script then rerun the QCs steps and upload the results to the reporting app.
fixes #330 
CR840