### PR TITLE
Overwrite with bgzip and tabix

### DIFF
--- a/analysis_driver/pipelines/common.py
+++ b/analysis_driver/pipelines/common.py
@@ -199,7 +199,7 @@ class SampleReview(segmentation.Stage):
 
 def bgzip_and_tabix(working_dir, vcf_file):
     bgzip_status = executor.execute(
-        '%s %s' % (toolset['bgzip'], vcf_file),
+        bash_commands.bgzip_command(vcf_file),
         job_name='bgzip',
         working_dir=working_dir,
         cpus=1,
@@ -207,7 +207,7 @@ def bgzip_and_tabix(working_dir, vcf_file):
     ).join()
 
     tabix_status = executor.execute(
-        '%s -p vcf %s' % (toolset['tabix'], vcf_file + '.gz'),
+        bash_commands.tabix_vcf_command( vcf_file + '.gz'),
         job_name='tabix',
         working_dir=working_dir,
         cpus=1,

--- a/analysis_driver/quality_control/relatedness.py
+++ b/analysis_driver/quality_control/relatedness.py
@@ -3,6 +3,7 @@ import csv
 from collections import Counter
 from egcg_core import executor, util, clarity
 from analysis_driver.tool_versioning import toolset
+from analysis_driver.util import bash_commands
 from analysis_driver.util.bash_commands import java_command
 from analysis_driver.segmentation import Stage, Parameter, ListParameter
 from analysis_driver.exceptions import PipelineError
@@ -201,26 +202,18 @@ class Peddy(RelatednessStage):
     def ped_file(self):
         return os.path.join(self.job_dir, 'ped.fam')
 
-    @property
-    def tabix_command(self):
-        return '%s -f -p vcf %s' % (toolset['tabix'], self.gatk_outfile + '.gz')
-
     def bgzip(self):
         return executor.execute(
-            self.bgzip_command,
+            bash_commands.bgzip_command(self.gatk_outfile),
             job_name='bgzip',
             working_dir=self.job_dir,
             cpus=1,
             mem=10
         ).join()
 
-    @property
-    def bgzip_command(self):
-        return '%s %s' % (toolset['bgzip'], self.gatk_outfile)
-
     def tabix_index(self):
         return executor.execute(
-            self.tabix_command,
+            bash_commands.tabix_vcf_command(self.gatk_outfile + '.gz'),
             job_name='tabix',
             working_dir=self.job_dir,
             cpus=1,

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -295,3 +295,11 @@ def java_command(memory, tmp_dir, jar):
         tmp_dir=tmp_dir,
         jar=jar
     )
+
+
+def bgzip_command(input_file):
+    return '%s -f %s' % (toolset['bgzip'], input_file)
+
+
+def tabix_vcf_command(input_file):
+    return '%s -f -p vcf %s' % (toolset['tabix'], input_file)

--- a/tests/test_bash_commands.py
+++ b/tests/test_bash_commands.py
@@ -184,3 +184,11 @@ def test_picard_insert_size_command():
 def test_java_command():
     obs = bash_commands.java_command(1, 'a_tmp_dir', 'a_jar_file')
     assert obs == 'java -Djava.io.tmpdir=a_tmp_dir -XX:+UseSerialGC -Xmx1G -jar a_jar_file '
+
+
+def test_tabix_command():
+    assert bash_commands.tabix_vcf_command('file.vcf.gz') == 'path/to/tabix -f -p vcf file.vcf.gz'
+
+
+def test_bgzip_command():
+    assert bash_commands.bgzip_command('file.vcf') == 'path/to/bgzip -f file.vcf'

--- a/tests/test_pipelines/test_variant_calling.py
+++ b/tests/test_pipelines/test_variant_calling.py
@@ -350,10 +350,10 @@ class TestVariantFiltration(TestVariantCalling):
 
 def _test_bgzip_and_tabix(executor, vcf_file):
     assert executor.call_args_list[1] == call(
-        'path/to/bgzip ' + vcf_file, cpus=1, job_name='bgzip', mem=8,
+        'path/to/bgzip -f ' + vcf_file, cpus=1, job_name='bgzip', mem=8,
         working_dir='tests/assets/jobs/test_dataset/gatk_var_calling'
     )
     assert executor.call_args_list[2] == call(
-        'path/to/tabix -p vcf ' + vcf_file + '.gz', cpus=1, job_name='tabix', mem=8,
+        'path/to/tabix -f -p vcf ' + vcf_file + '.gz', cpus=1, job_name='tabix', mem=8,
         working_dir='tests/assets/jobs/test_dataset/gatk_var_calling'
     )

--- a/tests/test_quality_control/test_relatedness.py
+++ b/tests/test_quality_control/test_relatedness.py
@@ -190,8 +190,16 @@ class TestPeddy(QCTester):
             working_dir='tests/assets/jobs/test_project_id'
         )
 
-    def test_tabix_command(self):
-        assert self.p.tabix_command == 'path/to/tabix -f -p vcf tests/assets/jobs/test_project_id/test_project_id_genotype_gvcfs.vcf.gz'
+    @patch('egcg_core.executor.execute')
+    def test_bgzip(self, mocked_execute):
+        self.p.bgzip()
+        mocked_execute.assert_called_with(
+            'path/to/bgzip -f tests/assets/jobs/test_project_id/test_project_id_genotype_gvcfs.vcf',
+            job_name='bgzip',
+            cpus=1,
+            mem=10,
+            working_dir='tests/assets/jobs/test_project_id'
+        )
 
 
 class TestParseRelatedness(QCTester):


### PR DESCRIPTION
make all tabix/bgzip command overwrite their output file if they exist already
Also refactor the commands to all use the same bash command generation.
fixes #340 