### PR TITLE
Project on valid project

### DIFF
--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -708,7 +708,7 @@ class MostRecentProc:
                 }
             }
             if self.get('status') != DATASET_RESUME:
-                payload['date_started'] = now()
+                payload['start_date'] = now()
 
             self.update_entity(status=DATASET_PROCESSING, pid=os.getpid())
             rest_communication.patch_entry('analysis_driver_procs', payload, 'proc_id', self.proc_id)

--- a/analysis_driver/pipelines/projects.py
+++ b/analysis_driver/pipelines/projects.py
@@ -16,7 +16,7 @@ name = 'project'
 
 def build_pipeline(dataset):
     sample_ids = [sample['sample_id'] for sample in dataset.samples_processed]
-    project_source = os.path.join(cfg['input_dir'], dataset.name)
+    project_source = os.path.join(cfg.query('project', 'input_dir'), dataset.name)
     gvcf_files = []
     for sample in dataset.samples_processed:
         # Only check if we have gvcf when the samples have been through human processing that generate a gvcf
@@ -69,5 +69,5 @@ class Output(segmentation.Stage):
 
         return output_data_and_archive(
             dir_with_linked_files,
-            os.path.join(cfg['output_dir'], self.dataset.name)
+            os.path.join(cfg.query('project', 'output_dir'), self.dataset.name)
         )

--- a/analysis_driver/pipelines/projects.py
+++ b/analysis_driver/pipelines/projects.py
@@ -20,9 +20,7 @@ def build_pipeline(dataset):
     gvcf_files = []
     for sample in dataset.samples_processed:
         # Only check if we have gvcf when the samples have been through a process that generate a gvcf
-        if query_dict(sample, 'aggregated.most_recent_proc.pipeline_used.toolset_type') in [
-            'human_sample_processing', 'non_human_sample_processing'
-        ]:
+        if query_dict(sample, 'aggregated.most_recent_proc.pipeline_used.name') in ['bcbio', 'variant_calling']:
             gvcf_file = find_file(project_source, sample['sample_id'], sample['user_sample_id'] + '.g.vcf.gz')
             if not gvcf_file:
                 raise PipelineError('Unable to find gVCF file for sample %s in %s' % (sample['sample_id'], project_source))

--- a/analysis_driver/pipelines/projects.py
+++ b/analysis_driver/pipelines/projects.py
@@ -16,11 +16,11 @@ name = 'project'
 
 def build_pipeline(dataset):
     sample_ids = [sample['sample_id'] for sample in dataset.samples_processed]
-    project_source = os.path.join(cfg.query('sample', 'output_dir'), dataset.name)
+    project_source = os.path.join(cfg['input_dir'], dataset.name)
     gvcf_files = []
     for sample in dataset.samples_processed:
-        # Only check if we have gvcf when the samples have been through a process that generate a gvcf
-        if query_dict(sample, 'aggregated.most_recent_proc.pipeline_used.name') in ['bcbio', 'variant_calling']:
+        # Only check if we have gvcf when the samples have been through human processing that generate a gvcf
+        if query_dict(sample, 'aggregated.most_recent_proc.pipeline_used.name') in ['bcbio']:
             gvcf_file = find_file(project_source, sample['sample_id'], sample['user_sample_id'] + '.g.vcf.gz')
             if not gvcf_file:
                 raise PipelineError('Unable to find gVCF file for sample %s in %s' % (sample['sample_id'], project_source))
@@ -69,5 +69,5 @@ class Output(segmentation.Stage):
 
         return output_data_and_archive(
             dir_with_linked_files,
-            os.path.join(cfg['project']['output_dir'], self.dataset.name)
+            os.path.join(cfg['output_dir'], self.dataset.name)
         )

--- a/analysis_driver/pipelines/projects.py
+++ b/analysis_driver/pipelines/projects.py
@@ -71,5 +71,5 @@ class Output(segmentation.Stage):
 
         return output_data_and_archive(
             dir_with_linked_files,
-            os.path.join(cfg['project']['input_dir'], self.dataset.name)
+            os.path.join(cfg['project']['output_dir'], self.dataset.name)
         )

--- a/analysis_driver/report_generation/run_crawler.py
+++ b/analysis_driver/report_generation/run_crawler.py
@@ -339,7 +339,8 @@ class RunCrawler(Crawler):
             picard_insert_size_metric = fastq_base + '_insertsize.metrics'
             if isfile(picard_insert_size_metric):
                 insert_types = mp.parse_picard_insert_size_metrics(picard_insert_size_metric)
-                mapping_statistics.update(insert_types.pop('FR'))
+                if 'FR' in insert_types:
+                    mapping_statistics.update(insert_types.pop('FR'))
                 if insert_types:
                     mapping_statistics[ELEMENT_NON_FR_INSERTS] = insert_types
             if mapping_statistics:

--- a/etc/example_analysisdriver.yaml
+++ b/etc/example_analysisdriver.yaml
@@ -9,7 +9,7 @@ default:
         delivery_dest:   /path/to/delivery/destination
 
     project:
-        input_dir:       /path/to/input/dir
+        input_dir:       tests/assets/test_projects/
         output_dir:      /path/to/input/dir
 
     rest_api:

--- a/etc/example_analysisdriver.yaml
+++ b/etc/example_analysisdriver.yaml
@@ -10,6 +10,7 @@ default:
 
     project:
         input_dir:       /path/to/input/dir
+        output_dir:      /path/to/input/dir
 
     rest_api:
         url: 'http://localhost:4999/api/0.1'

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -14,6 +14,7 @@ class IntegrationTest(ReportingAppIntegrationTest):
         patch('analysis_driver.client.load_config'),
         patch('egcg_core.clarity.find_project_name_from_sample', return_value='10015AT'),
         patch('egcg_core.clarity.get_plate_id_and_well', new=mocked_data.fake_get_plate_id_and_well),
+        patch('egcg_core.clarity.get_project', return_value=mocked_data.mocked_clarity_project),
         patch('egcg_core.clarity.get_run', return_value=mocked_data.mocked_clarity_run),
         patch('egcg_core.clarity.get_sample_gender'),
         patch('egcg_core.clarity.get_sample_genotype', return_value=set()),

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -352,3 +352,24 @@ class IntegrationTest(ReportingAppIntegrationTest):
         self.expect_equal(procs[0]['status'], 'finished', 'proc status finished')
 
         assert self._test_success
+
+    def test_project(self):
+        self.setup_test('project', 'test_project', 'project')
+        exit_status = client.main(['--project'])
+        self.assertEqual('exit status', exit_status, 0)
+
+        self.expect_output_files(
+            self.cfg['project']['files'],
+            base_dir=os.path.join(cfg['project']['output_dir'], self.project_id)
+        )
+
+        self.expect_stage_data('genotypegvcfs', 'relatedness', 'peddy', 'parserelatedness', 'md5sum', 'output',
+                               'cleanup')
+        ad_procs = rest_communication.get_document('analysis_driver_procs', where={'dataset_name': self.project_id})
+        self.expect_equal(
+            ad_procs['pipeline_used'],
+            {'toolset_type': 'toolset_type', 'name': 'project', 'toolset_version': 0},
+            'pipeline used'
+        )
+
+        assert self._test_success

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -381,7 +381,7 @@ class IntegrationTest(ReportingAppIntegrationTest):
         ad_procs = rest_communication.get_document('analysis_driver_procs', where={'dataset_name': self.project_id})
         self.expect_equal(
             ad_procs['pipeline_used'],
-            {'toolset_type': 'toolset_type', 'name': 'project', 'toolset_version': 0},
+            {'toolset_type': 'project_processing', 'name': 'project', 'toolset_version': 0},
             'pipeline used'
         )
 

--- a/integration_tests/mocked_data.py
+++ b/integration_tests/mocked_data.py
@@ -10,8 +10,11 @@ class NamedMock(Mock):  # don't import the tests - that patches `toolset`!
         return self.real_name
 
 
+mocked_clarity_project = NamedMock(real_name='10015AT', udf={'Number of Quoted Samples': 2})
+
+
 class MockedSample(NamedMock):
-    project = NamedMock(real_name='10015AT')
+    project = mocked_clarity_project
 
 
 mocked_lane_artifact_pool = NamedMock(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -571,7 +571,7 @@ class TestMostRecentProc(TestAnalysisDriver):
         mocked_patch.assert_called_with(
             'analysis_driver_procs',
             {
-                'date_started': 'now',
+                'start_date': 'now',
                 'pipeline_used': {
                     'name': 'some kind of variant calling',
                     'toolset_type': 'some kind of toolset',

--- a/tests/test_pipelines/test_projects.py
+++ b/tests/test_pipelines/test_projects.py
@@ -18,15 +18,16 @@ class TestProjects(TestAnalysisDriver):
             samples_processed=[
                 {
                     'sample_id': '10015AT0004', 'user_sample_id': 'test_user_sample1',
-                    'aggregated': {'most_recent_proc': {'pipeline_used': {'toolset_type': 'human_sample_processing'}}}
+                    'aggregated': {'most_recent_proc': {'pipeline_used': {'name': 'bcbio'}}}
                 },
                 {
                     'sample_id': '10015AT0003', 'user_sample_id': 'test_user_sample2',
-                    'aggregated': {'most_recent_proc': {'pipeline_used': {'toolset_type': 'non_human_sample_processing'}}}
+                    'aggregated': {'most_recent_proc': {'pipeline_used': {'name': 'bcbio'}}}
                 }
             ]
         )
         pipeline = projects.build_pipeline(two_sample_dataset)
+        # get a real pipeline
         assert len(pipeline.previous_stages) > 0
         one_sample_dataset = NamedMock(
             real_name=project_id,
@@ -34,6 +35,28 @@ class TestProjects(TestAnalysisDriver):
             samples_processed=[{'sample_id': '10015AT0004', 'user_sample_id': 'test_user_sample1'}]
         )
         pipeline = projects.build_pipeline(one_sample_dataset)
+        # get a single step pipeline
+        assert len(pipeline.previous_stages) == 0
+
+        multi_non_human_samples_dataset = NamedMock(
+            real_name=project_id,
+            species='Thingymy',
+            samples_processed=[
+                {
+                    'sample_id': 'sample1', 'user_sample_id': 'user_sample1',
+                    'aggregated': {'most_recent_proc': {'pipeline_used': {'name': 'qc'}}}
+                },
+                {
+                    'sample_id': 'sample2', 'user_sample_id': 'user_sample2',
+                    'aggregated': {'most_recent_proc': {'pipeline_used': {'name': 'qc'}}}
+                },
+                {
+                    'sample_id': 'sample3', 'user_sample_id': 'user_sample3',
+                    'aggregated': {'most_recent_proc': {'pipeline_used': {'name': 'qc'}}}
+                },
+            ]
+        )
+        pipeline = projects.build_pipeline(multi_non_human_samples_dataset)
         # get a single step pipeline
         assert len(pipeline.previous_stages) == 0
 

--- a/tests/test_pipelines/test_projects.py
+++ b/tests/test_pipelines/test_projects.py
@@ -16,19 +16,26 @@ class TestProjects(TestAnalysisDriver):
             real_name=project_id,
             species='Homo sapiens',
             samples_processed=[
-                {'sample_id': '10015AT0004', 'user_sample_id': 'test_user_sample1'},
-                {'sample_id': '10015AT0003', 'user_sample_id': 'test_user_sample2'}
+                {
+                    'sample_id': '10015AT0004', 'user_sample_id': 'test_user_sample1',
+                    'aggregated': {'most_recent_proc': {'pipeline_used': {'toolset_type': 'human_sample_processing'}}}
+                },
+                {
+                    'sample_id': '10015AT0003', 'user_sample_id': 'test_user_sample2',
+                    'aggregated': {'most_recent_proc': {'pipeline_used': {'toolset_type': 'non_human_sample_processing'}}}
+                }
             ]
         )
-        projects.build_pipeline(two_sample_dataset)
-
+        pipeline = projects.build_pipeline(two_sample_dataset)
+        assert len(pipeline.previous_stages) > 0
         one_sample_dataset = NamedMock(
             real_name=project_id,
             species='Homo sapiens',
             samples_processed=[{'sample_id': '10015AT0004', 'user_sample_id': 'test_user_sample1'}]
         )
-        with self.assertRaises(PipelineError):
-            projects.build_pipeline(one_sample_dataset)
+        pipeline = projects.build_pipeline(one_sample_dataset)
+        # get a single step pipeline
+        assert len(pipeline.previous_stages) == 0
 
 
 class TestMD5Sum(TestAnalysisDriver):


### PR DESCRIPTION
This PR makes the project process run an empty pipeline on projects that do not have enough gvcf.
Check if a sample should have a gvcf based on the pipeline it was processed with's name 

Also add in project process integration tests
closes #341 
Also add bugfix for cases when insert size metric is missing: close #352 