### PR TITLE
Support for multiprocessing when raising exceptions

### DIFF
--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 import re
 import signal
@@ -6,7 +7,6 @@ from datetime import datetime
 from errno import ESRCH
 from sys import modules
 from time import sleep
-from collections import OrderedDict
 from egcg_core import rest_communication, clarity
 from egcg_core.app_logging import AppLogger
 from egcg_core.config import cfg
@@ -28,7 +28,7 @@ class Dataset(AppLogger):
     type = None
     endpoint = None
     id_field = None
-    exceptions = OrderedDict()
+    exceptions = multiprocessing.Queue()  # This needs to be a Queue to be accessible from every subprocess
 
     def __init__(self, name, most_recent_proc=None):
         self.name = name
@@ -160,21 +160,23 @@ class Dataset(AppLogger):
         raise NotImplementedError
 
     def register_exception(self, luigi_task, exception):
-        self.exceptions[luigi_task.stage_name] = exception
+        self.exceptions.put((luigi_task.stage_name, exception))
 
     def raise_exceptions(self):
-        if self.exceptions:
-            self.critical('%s exceptions registered with dataset %s', len(self.exceptions), self.name)
-            for name in self.exceptions:
+        if not self.exceptions.empty():
+            first_exception = None
+            while not self.exceptions.empty():
+                name, exception = self.exceptions.get()
+                if not first_exception:
+                    first_exception = exception
                 self.critical(
                     'exception: %s%s raised in %s',
-                    self.exceptions[name].__class__.__name__,
-                    self.exceptions[name].args,
+                    exception.__class__.__name__,
+                    exception.args,
                     name
                 )
             # Only raise the first exception raised by tasks
-            task_name = list(self.exceptions.keys())[0]
-            raise self.exceptions[task_name]
+            raise first_exception
 
     def __str__(self):
         return '%s(name=%s)' % (self.__class__.__name__, self.name)

--- a/etc/example_analysisdriver.yaml
+++ b/etc/example_analysisdriver.yaml
@@ -64,7 +64,7 @@ default:
         fix_dup_unmapped: path/to/fix_dup_unmapped
 
     logging:
-        format: '[%(asctime)s][%(name)s][%(levelname)s] %(message)s'
+        format: '[%(asctime)s][%(processName)s][%(name)s][%(levelname)s] %(message)s'
         datefmt: '%Y-%b-%d %H:%M:%S'
         handlers:
             stdout:
@@ -111,3 +111,6 @@ default:
         baseuri: 'https://clarity.co.uk'
         username: apiuser
         password: apiuser
+
+    luigi:
+        local_scheduler: True

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -245,7 +245,7 @@ class IntegrationTest(ReportingAppIntegrationTest):
         self.expect_equal(
             ad_proc['status'], 'aborted', 'pipeline status'
         )
-        self.expect_stage_data([('setup', 9)], analysis_driver_proc=ad_proc['proc_id'])
+        self.expect_stage_data([('setup', 9)], where={'analysis_driver_proc': ad_proc['proc_id']})
 
     def test_bcbio(self):
         self.setup_test('sample', 'test_bcbio', 'bcbio')

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -1,13 +1,14 @@
 import os
 import subprocess
+
 from egcg_core import rest_communication, util
 from egcg_core.config import cfg
 from egcg_core.app_logging import logging_default
 from egcg_core.integration_testing import ReportingAppIntegrationTest
 from unittest.mock import Mock, patch
 from analysis_driver import client
-from analysis_driver.exceptions import SequencingRunError
 from integration_tests import mocked_data
+from integration_tests.mocked_data import MockedRunProcess, mocked_flowcell_pooling
 
 
 class IntegrationTest(ReportingAppIntegrationTest):
@@ -146,10 +147,16 @@ class IntegrationTest(ReportingAppIntegrationTest):
         for e in sorted(exp):
             self.expect_equal(util.query_dict(obs, e), exp[e], e)
 
-    def expect_stage_data(self, *stage_names):
-        stages = rest_communication.get_documents('analysis_driver_stages')
+    def expect_stage_data(self, stage_names, **query_kw):
+        """
+        Take a list of stage name as string assuming exit status is 0 or as tuple with (stage_name, exist status).
+        Compare to the list of stage name and exist status retrieve from the analysis_driver_stages endpoint using the
+        keyword arguments provided.
+        """
+        stages = rest_communication.get_documents('analysis_driver_stages', **query_kw)
         obs = {s['stage_name']: s.get('exit_status') for s in stages}
-        self.expect_equal(obs, {s: 0 for s in stage_names}, 'stages')
+        exp = dict([s if type(s) == tuple else (s, 0) for s in stage_names])
+        self.expect_equal(obs, exp, 'stages')
 
     def _check_md5(self, fp):
         if not os.path.isfile(fp):
@@ -213,10 +220,10 @@ class IntegrationTest(ReportingAppIntegrationTest):
                 ),
                 self.cfg['demultiplexing']['lane_qc']
             )
-        self.expect_stage_data('setup', 'wellduplicates', 'bcl2fastq', 'phixdetection', 'fastqfilter', 'seqtkfqchk',
+        self.expect_stage_data(['setup', 'wellduplicates', 'bcl2fastq', 'phixdetection', 'fastqfilter', 'seqtkfqchk',
                                'md5sum', 'fastqc', 'integritycheck', 'qcoutput1', 'dataoutput', 'cleanup',
                                'samtoolsdepthmulti', 'picardinsertsizemulti', 'qcoutput2', 'runreview',
-                               'picardmarkduplicatemulti', 'samtoolsstatsmulti', 'bwaalignmulti')
+                               'picardmarkduplicatemulti', 'samtoolsstatsmulti', 'bwaalignmulti'])
 
         self.expect_equal(
             rest_communication.get_document('analysis_driver_procs')['pipeline_used'],
@@ -226,14 +233,19 @@ class IntegrationTest(ReportingAppIntegrationTest):
         assert self._test_success
 
     def test_demultiplexing_aborted(self):
-        self.setup_test('sample', 'test_demultiplexing', 'demultiplexing')
-        with patch('analysis_driver.pipelines.demultiplexing.Setup._run', side_effect=SequencingRunError):
-            exit_status = client.main(['--run'])
-            self.assertEqual('exit status', exit_status, 0)
+        self.setup_test('sample', 'test_demultiplexing_aborted', 'demultiplexing')
 
-            self.expect_equal(
-                rest_communication.get_document('analysis_driver_procs')['status'], 'aborted'
-            )
+        mocked_clarity_run = MockedRunProcess(udf={'Run Status': 'RunAborted'}, container=mocked_flowcell_pooling)
+        with patch('egcg_core.clarity.get_run', return_value=mocked_clarity_run):
+            exit_status = client.main(['--run'])
+
+        self.assertEqual('exit status', exit_status, 0)
+        ad_proc = rest_communication.get_document('analysis_driver_procs', where={'dataset_name': self.run_id})
+
+        self.expect_equal(
+            ad_proc['status'], 'aborted', 'pipeline status'
+        )
+        self.expect_stage_data([('setup', 9)], analysis_driver_proc=ad_proc['proc_id'])
 
     def test_bcbio(self):
         self.setup_test('sample', 'test_bcbio', 'bcbio')
@@ -250,9 +262,9 @@ class IntegrationTest(ReportingAppIntegrationTest):
             base_dir=os.path.join(cfg['sample']['output_dir'], self.project_id, self.sample_id)
         )
 
-        self.expect_stage_data('mergefastqs', 'fastqc', 'genotypevalidation', 'bcbio', 'fastqscreen',
+        self.expect_stage_data(['mergefastqs', 'fastqc', 'genotypevalidation', 'bcbio', 'fastqscreen',
                                'fixunmapped', 'blast', 'gendervalidation', 'vcfstats', 'samtoolsdepth',
-                               'verifybamid', 'sampledataoutput', 'md5sum', 'cleanup', 'samplereview')
+                               'verifybamid', 'sampledataoutput', 'md5sum', 'cleanup', 'samplereview'])
 
         self.expect_equal(
             rest_communication.get_document('analysis_driver_procs')['pipeline_used'],
@@ -283,10 +295,10 @@ class IntegrationTest(ReportingAppIntegrationTest):
             base_dir=os.path.join(cfg['sample']['output_dir'], self.project_id, self.sample_id)
         )
 
-        self.expect_stage_data('mergefastqs', 'samplereview', 'fastqscreen', 'printreads', 'blast', 'baserecal',
+        self.expect_stage_data(['mergefastqs', 'samplereview', 'fastqscreen', 'printreads', 'blast', 'baserecal',
                                'samtoolsdepth', 'vcfstats', 'selectvariants', 'fastqc', 'variantfiltration',
                                'cleanup', 'realign', 'realigntarget', 'samtoolsstats', 'haplotypecaller',
-                               'md5sum', 'bwamem', 'sampledataoutput', 'genotypegvcfs')
+                               'md5sum', 'bwamem', 'sampledataoutput', 'genotypegvcfs'])
 
         self.expect_equal(
             rest_communication.get_document('analysis_driver_procs')['pipeline_used'],
@@ -310,9 +322,9 @@ class IntegrationTest(ReportingAppIntegrationTest):
             rest_communication.get_document('samples', where={'sample_id': self.sample_id}),
             self.cfg['qc']['qc']
         )
-        self.expect_stage_data('vcfstats', 'selectvariants', 'fastqc', 'variantfiltration', 'samtoolsdepth',
+        self.expect_stage_data(['vcfstats', 'selectvariants', 'fastqc', 'variantfiltration', 'samtoolsdepth',
                                'mergefastqs', 'samtoolsstats', 'samplereview', 'haplotypecaller', 'cleanup',
-                               'fastqscreen', 'md5sum', 'bwamem', 'sampledataoutput', 'genotypegvcfs', 'blast')
+                               'fastqscreen', 'md5sum', 'bwamem', 'sampledataoutput', 'genotypegvcfs', 'blast'])
 
         self.expect_equal(
             rest_communication.get_document('analysis_driver_procs')['pipeline_used'],
@@ -387,8 +399,8 @@ class IntegrationTest(ReportingAppIntegrationTest):
             base_dir=os.path.join(cfg['project']['output_dir'], self.project_id)
         )
 
-        self.expect_stage_data('genotypegvcfs', 'relatedness', 'peddy', 'parserelatedness', 'md5sum', 'output',
-                               'cleanup')
+        self.expect_stage_data(['genotypegvcfs', 'relatedness', 'peddy', 'parserelatedness', 'md5sum', 'output',
+                               'cleanup'])
         ad_procs = rest_communication.get_document('analysis_driver_procs', where={'dataset_name': self.project_id})
         self.expect_equal(
             ad_procs['pipeline_used'],

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,7 @@
 import os
 import signal
+import time
+
 import pytest
 from sys import modules
 from unittest.mock import patch, Mock, PropertyMock, call
@@ -176,6 +178,11 @@ class TestDataset(TestAnalysisDriver):
 
     def test_raise_exceptions(self):
         self.dataset.register_exception(Mock(stage_name='task1'), SequencingRunError('RunErrored'))
+        # Give time for the exception to be pickled.
+        # From the documentation:
+        # 'After putting an object on an empty queue there may be an infinitesimal delay before the queue’s empty()
+        # method returns False and get_nowait() can return without raising queue.Empty.'
+        time.sleep(.1)
         with pytest.raises(SequencingRunError):
             self.dataset.raise_exceptions()
 

--- a/tests/test_pipelines/test_pipeline.py
+++ b/tests/test_pipelines/test_pipeline.py
@@ -1,16 +1,12 @@
-import unittest
 from unittest.mock import Mock, patch
 
-import luigi
 import pytest
-from luigi import Task, Event
 
 from analysis_driver import segmentation
 from analysis_driver.dataset import RunDataset
 from analysis_driver.exceptions import SequencingRunError, PipelineError
 from analysis_driver.pipelines import pipeline
 from tests import TestAnalysisDriver
-from tests.test_analysisdriver import NamedMock
 
 
 class ExceptionStage(segmentation.Stage):

--- a/tests/test_pipelines/test_pipeline.py
+++ b/tests/test_pipelines/test_pipeline.py
@@ -48,7 +48,7 @@ class TestPipeline(TestAnalysisDriver):
     def test_successful_pipeline(self):
         assert self._pipeline_with_stage(SuccessfulStage) == 0
 
-    def test_failling_pipeline(self):
+    def test_failing_pipeline(self):
         with pytest.raises(PipelineError):
             self._pipeline_with_stage(FailingStage)
 

--- a/tests/test_pipelines/test_pipeline.py
+++ b/tests/test_pipelines/test_pipeline.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import luigi
+import pytest
+from luigi import Task, Event
+
+from analysis_driver import segmentation
+from analysis_driver.dataset import RunDataset
+from analysis_driver.exceptions import SequencingRunError, PipelineError
+from analysis_driver.pipelines import pipeline
+from tests import TestAnalysisDriver
+from tests.test_analysisdriver import NamedMock
+
+
+class ExceptionStage(segmentation.Stage):
+    def _run(self):
+        raise SequencingRunError('Aborted')
+
+
+class SuccessfulStage(segmentation.Stage):
+    def _run(self):
+        pass
+
+
+class FailingStage(segmentation.Stage):
+    def _run(self):
+        return 1
+
+
+class TestPipeline(TestAnalysisDriver):
+
+    def _pipeline_with_stage(self, stage_class):
+        dataset = RunDataset(name='a_sample')
+        patches = []
+        for function_to_patch in ['start', 'get_stage', 'start_stage', 'end_stage', 'resolve_pipeline_and_toolset']:
+            p = patch.object(RunDataset, function_to_patch)
+            p.start()
+            patches.append(p)
+
+        dataset.pipeline = Mock(build_pipeline=Mock(return_value=stage_class(dataset=dataset)))
+        try:
+            return pipeline(dataset)
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_pipeline_with_exceptions(self):
+        with pytest.raises(SequencingRunError):
+            self._pipeline_with_stage(ExceptionStage)
+
+    def test_successful_pipeline(self):
+        assert self._pipeline_with_stage(SuccessfulStage) == 0
+
+    def test_failling_pipeline(self):
+        with pytest.raises(PipelineError):
+            self._pipeline_with_stage(FailingStage)
+
+


### PR DESCRIPTION
Exception raised in stages are now stored in a multiprocessing.Queue.
In order to receive them when multiprocessing is active
This includes PipelineError which is raised when a stage returns non 0 exist code.
This will closes #335 but is not very elegant, especially the fact that there are Run specific action in the `client.py` which should be process type agnostic.
If you can think of a better solution do let me know.
