### PR TITLE
Fix early alignment when a run is aborted

### DIFF
--- a/analysis_driver/pipelines/demultiplexing.py
+++ b/analysis_driver/pipelines/demultiplexing.py
@@ -242,6 +242,13 @@ class WaitForRead2(DemultiplexingStage):
         while current_cycle < required_number_of_cycle and self.dataset.is_sequencing():
             time.sleep(1200)
             current_cycle = sorted(interop_metrics.get_cycles_extracted(self.dataset.input_dir))[-1]
+
+        # make sure the run is not aborted or errored before continuing with the rest of the pipeline
+        run_status = self.dataset.lims_run.udf.get('Run Status')
+        if run_status not in ['RunCompleted', 'RunStarted', 'RunPaused']:
+            self.error('Run status is \'%s\'. Stopping.', run_status)
+            raise SequencingRunError(run_status)
+
         return 0
 
 

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -211,11 +211,12 @@ class IntegrationTest(ReportingAppIntegrationTest):
                 ),
                 self.cfg['demultiplexing']['lane_qc']
             )
-        self.expect_stage_data(['setup', 'wellduplicates', 'bcl2fastq', 'phixdetection', 'fastqfilter', 'seqtkfqchk',
-                               'md5sum', 'fastqc', 'integritycheck', 'qcoutput1', 'dataoutput', 'cleanup',
-                               'samtoolsdepthmulti', 'picardinsertsizemulti', 'qcoutput2', 'runreview',
-                               'picardmarkduplicatemulti', 'samtoolsstatsmulti', 'bwaalignmulti', 'waitforread2',
-                               'bcl2fastqhalfrun', 'picardgcbias'])
+        self.expect_stage_data([
+            'setup', 'wellduplicates', 'bcl2fastq', 'phixdetection', 'fastqfilter', 'seqtkfqchk', 'md5sum', 'fastqc',
+            'integritycheck', 'qcoutput1', 'dataoutput', 'cleanup', 'samtoolsdepthmulti', 'picardinsertsizemulti',
+            'qcoutput2', 'runreview', 'picardmarkduplicatemulti', 'samtoolsstatsmulti', 'bwaalignmulti', 'waitforread2',
+            'bcl2fastqpartialrun', 'picardgcbias'
+        ])
 
         proc = rest_communication.get_document('analysis_driver_procs')
         self.expect_equal(
@@ -246,7 +247,8 @@ class IntegrationTest(ReportingAppIntegrationTest):
         self.expect_equal(
             ad_proc['status'], 'aborted', 'pipeline status'
         )
-        self.expect_stage_data([('setup', 9)], where={'analysis_driver_proc': ad_proc['proc_id']})
+        stages = [('setup', 9), ('waitforread2', 9)]
+        self.expect_stage_data(stages, where={'analysis_driver_proc': ad_proc['proc_id']})
 
     def test_bcbio(self):
         self.setup_test('sample', 'test_bcbio', 'bcbio')

--- a/tests/test_pipelines/test_demultiplexing.py
+++ b/tests/test_pipelines/test_demultiplexing.py
@@ -2,7 +2,11 @@ import os
 import shutil
 from os.path import join
 from unittest.mock import Mock, patch
+
+import pytest
 from egcg_core.constants import ELEMENT_PROJECT_ID, ELEMENT_LANE, ELEMENT_SAMPLE_INTERNAL_ID
+
+from analysis_driver.exceptions import SequencingRunError
 from tests.test_analysisdriver import TestAnalysisDriver, NamedMock
 from analysis_driver.util import bash_commands
 from analysis_driver.pipelines import demultiplexing as dm
@@ -122,6 +126,23 @@ class TestWaitForRead2(TestAnalysisDriver):
             assert mcycle.call_count == 2
             mcycle.assert_called_with('path/to/input')
             msleep.assert_called_with(1200)
+
+    def test_run_aborted(self):
+        # Run info state 150 cycle for first read and 8 index cycle + 50 cycle for second read = 208
+        run_info = Mock(reads=Mock(upstream_read=Mock(attrib={'NumCycles': '150'}), index_lengths=[8]))
+        dataset = NamedMock(real_name='testrun', run_info=run_info, input_dir='path/to/input',
+                            lims_run=Mock(udf={'Run Status': 'RunAborted'}))
+
+        # cycle extracted states 209 cycles done
+        pcycles = patch('analysis_driver.quality_control.interop_metrics.get_cycles_extracted',
+                        return_value=range(1, 209))
+
+        with pcycles as mcycle:
+            with pytest.raises(SequencingRunError):
+                self.stage = dm.WaitForRead2(dataset=dataset)
+                self.stage._run()
+            assert mcycle.call_count == 1
+            mcycle.assert_called_once_with('path/to/input')
 
 
 class TestPostDemultiplexing(TestAnalysisDriver):

--- a/tests/test_pipelines/test_demultiplexing.py
+++ b/tests/test_pipelines/test_demultiplexing.py
@@ -99,7 +99,8 @@ class TestWaitForRead2(TestAnalysisDriver):
 
         # Run info state 150 cycle for first read and 8 index cycle + 50 cycle for second read = 208
         run_info = Mock(reads=Mock(upstream_read=Mock(attrib={'NumCycles': '150'}), index_lengths=[8]))
-        dataset = NamedMock(real_name='testrun', run_info=run_info, input_dir='path/to/input')
+        dataset = NamedMock(real_name='testrun', run_info=run_info, input_dir='path/to/input',
+                            lims_run=Mock(udf={'Run Status': 'RunStarted'}))
 
         # cycle extracted states 310 cycles done
         pcycles = patch('analysis_driver.quality_control.interop_metrics.get_cycles_extracted',


### PR DESCRIPTION
This PR fixes an issue introduced when combining early alignment #368 and support for aborted runs #362.
It will allow the pipeline to finish with no error in the event of an aborted run.
