### PR TITLE
IDT barcodes, more accurate tool version reporting, genome used

### DIFF
--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -210,8 +210,7 @@ class Dataset(AppLogger):
 
     def resolve_pipeline_and_toolset(self):
         instruction = self._pipeline_instruction()
-        toolset.select_type(instruction['toolset_type'])
-        toolset.select_version(instruction['toolset_version'])
+        toolset.configure(instruction['toolset_type'], instruction['toolset_version'])
         self.pipeline = pipeline_register[instruction['name']]
 
 

--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -744,6 +744,9 @@ class MostRecentProc:
             if self.get('status') != DATASET_RESUME:
                 payload['start_date'] = now()
 
+            if self.dataset.type == 'sample':
+                payload['genome_used'] = self.dataset.genome_version
+
             self.update_entity(status=DATASET_PROCESSING, pid=os.getpid())
             rest_communication.patch_entry('analysis_driver_procs', payload, 'proc_id', self.proc_id)
 

--- a/analysis_driver/pipelines/common.py
+++ b/analysis_driver/pipelines/common.py
@@ -178,6 +178,8 @@ class MergeFastqs(VarCallingStage):
         exit_status = executor.execute(
             bash_commands.bcbio_prepare_samples(self.job_dir, bcbio_csv_file),
             job_name='bcbio_prepare_samples',
+            cpus=1,
+            mem=2,
             working_dir=self.job_dir
         ).join()
 

--- a/analysis_driver/pipelines/variant_calling.py
+++ b/analysis_driver/pipelines/variant_calling.py
@@ -136,6 +136,7 @@ class RealignTarget(GATKStage):
             realign_target_cmd,
             job_name='gatk_realign_target',
             working_dir=self.gatk_run_dir,
+            cpus=1,
             mem=32
         ).join()
 
@@ -157,6 +158,7 @@ class Realign(GATKStage):
             realign_cmd,
             job_name='gatk_indel_realign',
             working_dir=self.gatk_run_dir,
+            cpus=1,
             mem=32
         ).join()
 
@@ -200,6 +202,7 @@ class GenotypeGVCFs(GATKStage):
             genotype_gvcfs_cmd,
             job_name='gatk_genotype_gvcfs',
             working_dir=self.gatk_run_dir,
+            cpus=1,
             mem=16
         ).join()
 
@@ -215,6 +218,7 @@ class SelectVariants(GATKStage):
             select_var_command,
             job_name='var_filtration',
             working_dir=self.gatk_run_dir,
+            cpus=1,
             mem=16
         ).join()
         return select_variants_status + bgzip_and_tabix(self.gatk_run_dir, self.raw_snp_vcf)
@@ -238,6 +242,7 @@ class VariantFiltration(GATKStage):
             var_filter_command,
             job_name='var_filtration',
             working_dir=self.gatk_run_dir,
+            cpus=1,
             mem=16
         ).join()
         return variant_filter_status + bgzip_and_tabix(self.gatk_run_dir, self.filter_snp_vcf)

--- a/analysis_driver/quality_control/interop_metrics.py
+++ b/analysis_driver/quality_control/interop_metrics.py
@@ -27,22 +27,27 @@ class BadTileCycleDetector(AppLogger):
     def read_interop_metrics(self):
         run_metrics = RunMetrics()
         run_metrics.read(self.run_dir)
-        q_metric_set = run_metrics.q_metric_set()
-        metrics = q_metric_set.metrics()
+        metrics = run_metrics.q_metric_set().metrics()
 
         self.all_lanes = {}
         for lane in range(1, 9):
             self.all_lanes[lane] = ({}, {})
 
         for i in range(metrics.size()):
-            tile_dict, cycle_dict = self.all_lanes[metrics[i].lane()]
-            if metrics[i].tile() not in tile_dict:
-                tile_dict[metrics[i].tile()] = [None] * self.ncycles
-            if metrics[i].cycle() not in cycle_dict:
-                cycle_dict[metrics[i].cycle()] = []
+            m = metrics[i]
+            lane = m.lane()
+            tile = m.tile()
+            cycle = m.cycle()
 
-            tile_dict[metrics[i].tile()][metrics[i].cycle()-1] = metrics[i].qscore_hist()
-            cycle_dict[metrics[i].cycle()].append(metrics[i].qscore_hist())
+            tile_dict, cycle_dict = self.all_lanes[lane]
+            if tile not in tile_dict:
+                tile_dict[tile] = [None] * self.ncycles
+            if cycle not in cycle_dict:
+                cycle_dict[cycle] = []
+
+            qscore = m.qscore_hist()
+            tile_dict[tile][cycle-1] = qscore
+            cycle_dict[cycle].append(qscore)
 
     @staticmethod
     def windows(l, window_size):

--- a/analysis_driver/reader/demultiplexing_parsers.py
+++ b/analysis_driver/reader/demultiplexing_parsers.py
@@ -394,22 +394,29 @@ def parse_interop_summary(summary_file):
                 sections[section_name].append(sp_line)
         return sections
 
+    def to_float(data):
+        n = float(data)
+        if math.isnan(n):
+            return None
+
+        return n
+
     def parse_read_section(lines):
         values_per_lane = {}
         for sp_line in lines[1:]:
             if sp_line[0].isdigit() and sp_line[1] == '-':
                 values_per_lane[sp_line[0]] = {
-                    'pc_clust_pf': float(sp_line[4].split()[0]),  # avg Cluster PF
-                    'pc_clust_pf_stdev': float(sp_line[4].split()[2]),  # std dev Cluster PF
-                    'phasing': float(sp_line[5].split('/')[0].strip()),  # Phasing
-                    'prephasing': float(sp_line[5].split('/')[1].strip()),  # Prephasing
-                    'pc_q30': float(sp_line[10]),  # '%>=Q30'
-                    'pc_aligned': float(sp_line[13].split()[0]),  # avg %aligned'
-                    'pc_aligned_stdev': float(sp_line[13].split()[2]),  # std dev %aligned '
-                    'pc_error': float(sp_line[14].split()[0]),  # 'avg %error'
-                    'pc_error_stdev': float(sp_line[14].split()[2]),  # 'std dev %error'
-                    'intensity_c1': float(sp_line[18].split()[0]),  # ' avg Intensity C1'
-                    'intensity_c1_stdev': float(sp_line[18].split()[2]),  # 'std dev Intensity C1'
+                    'pc_clust_pf': to_float(sp_line[4].split()[0]),  # avg Cluster PF
+                    'pc_clust_pf_stdev': to_float(sp_line[4].split()[2]),  # std dev Cluster PF
+                    'phasing': to_float(sp_line[5].split('/')[0].strip()),  # Phasing
+                    'prephasing': to_float(sp_line[5].split('/')[1].strip()),  # Prephasing
+                    'pc_q30': to_float(sp_line[10]),  # '%>=Q30'
+                    'pc_aligned': to_float(sp_line[13].split()[0]),  # avg %aligned'
+                    'pc_aligned_stdev': to_float(sp_line[13].split()[2]),  # std dev %aligned '
+                    'pc_error': to_float(sp_line[14].split()[0]),  # 'avg %error'
+                    'pc_error_stdev': to_float(sp_line[14].split()[2]),  # 'std dev %error'
+                    'intensity_c1': to_float(sp_line[18].split()[0]),  # ' avg Intensity C1'
+                    'intensity_c1_stdev': to_float(sp_line[18].split()[2]),  # 'std dev Intensity C1'
                 }
         return values_per_lane
 

--- a/analysis_driver/tool_versioning.py
+++ b/analysis_driver/tool_versioning.py
@@ -1,6 +1,8 @@
 import yaml
 import subprocess
 from os.path import isfile
+from shutil import copyfile
+from multiprocessing import Lock
 from egcg_core.app_logging import AppLogger
 from analysis_driver.config import cfg, tool_versioning_cfg
 from analysis_driver.exceptions import AnalysisDriverError
@@ -13,18 +15,17 @@ class Toolset(AppLogger):
         self.versioning_cfg = tool_versioning_cfg
         self.version = None
         self.type = None
+        self.versions_file = None
+        self.lock = Lock()
 
     def latest_version(self, toolset_type):
         return max(self.versioning_cfg['toolsets'][toolset_type])
 
-    def select_type(self, toolset_type):
+    def configure(self, toolset_type, toolset_version, versions_file):
         self.type = toolset_type
+        self.version = toolset_version
+        self.versions_file = versions_file
 
-    def select_version(self, version):
-        if self.type is None:
-            raise AnalysisDriverError('Tried to select a toolset version with no type set')
-
-        self.version = version
         self.tools = {}
         self.tool_versions = {}
         self.info('Selected %s toolset version %s', self.type, self.version)
@@ -37,14 +38,14 @@ class Toolset(AppLogger):
         if toolname in self.versioning_cfg['toolsets'][self.type][self.version]:
             self.tools[toolname] = self.add_versioned_tool(toolname)
         else:
-            config = cfg['tools'].get(toolname)
-            if not config:
+            executable = cfg['tools'].get(toolname)
+            if not executable:
                 raise AnalysisDriverError('Referenced tool %s not present in config' % toolname)
 
-            if isinstance(config, list):
-                config = sorted(config)[-1]
+            if isinstance(executable, list):
+                executable = sorted(executable)[-1]
 
-            self.tools[toolname] = config
+            self.tools[toolname] = executable
 
     def add_versioned_tool(self, toolname):
         """
@@ -52,9 +53,6 @@ class Toolset(AppLogger):
         in cfg['tools'].
         :param str toolname:
         """
-        if toolname in self.tools:
-            self.debug('Tried to add %s - already added')
-            return self.tools[toolname]
 
         version = self.resolve(toolname, 'version')
         version_cmd = self.resolve(toolname, 'version_cmd')
@@ -62,15 +60,16 @@ class Toolset(AppLogger):
         if dependency:
             self.add_tool(dependency)
 
-        config = cfg['tools'][toolname]
-        if type(config) is str:
-            config = [config]
+        executables = cfg['tools'][toolname]
+        if type(executables) is str:
+            executables = [executables]
 
-        for c in config:
-            if self.check_version(toolname, c, version, version_cmd, self.tools.get(dependency)):
+        for e in executables:
+            if self.check_version(toolname, e, version, version_cmd, self.tools.get(dependency)):
                 self.tool_versions[toolname] = version
-                self.debug('Resolved %s version %s: %s', toolname, version, c)
-                return c
+                self.update_versions_file(toolname, version)
+                self.debug('Resolved %s version %s: %s', toolname, version, e)
+                return e
 
         raise AnalysisDriverError('Could not find version %s for %s' % (version, toolname))
 
@@ -112,15 +111,20 @@ class Toolset(AppLogger):
             return self.resolve(toolname, val, toolset_version - 1)
 
     def write_to_yaml(self, file_path):
-        if isfile(file_path):
-            with open(file_path, 'r') as f:
-                tool_versions = yaml.safe_load(f)
-        else:
-            tool_versions = {}
+        copyfile(self.versions_file, file_path)
 
-        tool_versions.update(self.tool_versions)
-        with open(file_path, 'w') as f:
-            f.write(yaml.safe_dump(tool_versions, default_flow_style=False))
+    def update_versions_file(self, toolname, version):
+        with self.lock:
+            if isfile(self.versions_file):
+                with open(self.versions_file, 'r') as f:
+                    tool_versions = yaml.safe_load(f)
+            else:
+                tool_versions = {}
+
+            tool_versions[toolname] = version
+
+            with open(self.versions_file, 'w') as f:
+                f.write(yaml.safe_dump(tool_versions, default_flow_style=False))
 
     @staticmethod
     def _get_stdout(cmd):
@@ -129,7 +133,9 @@ class Toolset(AppLogger):
         return stdout.strip().decode('utf-8')
 
     def __getitem__(self, item):
-        self.add_tool(item)
+        if item not in self.tools:
+            self.add_tool(item)
+
         return self.tools[item]
 
 

--- a/analysis_driver/tool_versioning.py
+++ b/analysis_driver/tool_versioning.py
@@ -26,10 +26,6 @@ class Toolset(AppLogger):
         self.version = version
         self.tools = {}
         self.tool_versions = {}
-
-        for k in cfg['tools']:
-            self.add_tool(k)
-
         self.info('Selected %s toolset version %s', self.type, self.version)
 
     @property
@@ -40,7 +36,10 @@ class Toolset(AppLogger):
         if toolname in self.versioning_cfg['toolsets'][self.type][self.version]:
             self.tools[toolname] = self.add_versioned_tool(toolname)
         else:
-            config = cfg['tools'][toolname]
+            config = cfg['tools'].get(toolname)
+            if not config:
+                raise AnalysisDriverError('Referenced tool %s not present in config' % toolname)
+
             if isinstance(config, list):
                 config = sorted(config)[-1]
 
@@ -122,6 +121,7 @@ class Toolset(AppLogger):
         return stdout.strip().decode('utf-8')
 
     def __getitem__(self, item):
+        self.add_tool(item)
         return self.tools[item]
 
 

--- a/analysis_driver/tool_versioning.py
+++ b/analysis_driver/tool_versioning.py
@@ -1,5 +1,6 @@
 import yaml
 import subprocess
+from os.path import isfile
 from egcg_core.app_logging import AppLogger
 from analysis_driver.config import cfg, tool_versioning_cfg
 from analysis_driver.exceptions import AnalysisDriverError
@@ -111,8 +112,15 @@ class Toolset(AppLogger):
             return self.resolve(toolname, val, toolset_version - 1)
 
     def write_to_yaml(self, file_path):
+        if isfile(file_path):
+            with open(file_path, 'r') as f:
+                tool_versions = yaml.safe_load(f)
+        else:
+            tool_versions = {}
+
+        tool_versions.update(self.tool_versions)
         with open(file_path, 'w') as f:
-            f.write(yaml.safe_dump(self.tool_versions, default_flow_style=False))
+            f.write(yaml.safe_dump(tool_versions, default_flow_style=False))
 
     @staticmethod
     def _get_stdout(cmd):

--- a/integration_tests/mocked_data.py
+++ b/integration_tests/mocked_data.py
@@ -27,7 +27,7 @@ mocked_lane_artifact_pool = NamedMock(
                       samples=[MockedSample(real_name='10015AT0002', id='LP6002014-DTP_A02')]),
             NamedMock(reagent_labels=['D703-D502 (CGCTCATT-ATAGAGGC)'],
                       samples=[MockedSample(real_name='10015AT0003', id='LP6002014-DTP_A03')]),
-            NamedMock(reagent_labels=['D704-D502 (GAGATTCC-ATAGAGGC)'],
+            NamedMock(reagent_labels=['001A IDT-ILMN TruSeq DNA-RNA UD 96 Indexes Plate_UDI0001 (GAGATTCC-ATAGAGGC)'],
                       samples=[MockedSample(real_name='10015AT0004', id='LP6002014-DTP_A04')]),
             NamedMock(reagent_labels=['D705-D502 (ATTCAGAA-ATAGAGGC)'],
                       samples=[MockedSample(real_name='10015AT0006', id='LP6002014-DTP_A05')]),

--- a/tests/test_analysisdriver.py
+++ b/tests/test_analysisdriver.py
@@ -23,5 +23,5 @@ class TestAnalysisDriver(TestCase):
     def setUpClass(cls):
         cfg.load_config_file(etc_config('example_analysisdriver.yaml'))
         tool_versioning.toolset.versioning_cfg.load_config_file(join(cls.assets_path, 'tool_versioning.yaml'))
-        tool_versioning.toolset.select_type('fake_tools')
-        tool_versioning.toolset.select_version(0)
+        tool_versioning.toolset.configure('fake_tools', 0, None)
+        tool_versioning.toolset.update_versions_file = Mock()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -611,6 +611,8 @@ class TestMostRecentProc(TestAnalysisDriver):
     @patched_update
     def test_start(self, mocked_update, mocked_patch, mocked_now):
         self.proc.dataset.pipeline = NamedMock(real_name='some kind of variant calling')
+        self.proc.dataset.type = 'sample'
+        self.proc.dataset.genome_version = 'Tthi_1.0'
         with patched_pid:
             self.proc.start()
         mocked_update.assert_called_with(status=c.DATASET_PROCESSING, pid=1)
@@ -622,7 +624,8 @@ class TestMostRecentProc(TestAnalysisDriver):
                     'name': 'some kind of variant calling',
                     'toolset_type': 'some kind of toolset',
                     'toolset_version': 3
-                }
+                },
+                'genome_used': 'Tthi_1.0'
             },
             'proc_id',
             'a_proc_id'

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -194,8 +194,7 @@ class TestDataset(TestAnalysisDriver):
         with patch(ppath + 'toolset') as mocked_toolset:
             self.dataset.resolve_pipeline_and_toolset()
 
-        mocked_toolset.select_type.assert_called_with('a_toolset')
-        mocked_toolset.select_version.assert_called_with(3)
+        mocked_toolset.configure.assert_called_with('a_toolset', 3)
         assert self.dataset.pipeline.name == 'qc'
 
     @patch(ppath + 'toolset', new=Toolset())

--- a/tests/test_pipelines/test_common.py
+++ b/tests/test_pipelines/test_common.py
@@ -113,7 +113,7 @@ class TestMergeFastqs(TestCommon):
             command = 'path/to/bcbio/bin/bcbio_prepare_samples.py ' \
                       '--out tests/assets/jobs/test_dataset/merged' \
                       ' --csv tests/assets/jobs/test_dataset/samples_test_dataset.csv'
-            mock_execute.assert_any_call(command, job_name='bcbio_prepare_samples', working_dir='tests/assets/jobs/test_dataset'),
+            mock_execute.assert_any_call(command, cpus=1, mem=2, job_name='bcbio_prepare_samples', working_dir='tests/assets/jobs/test_dataset'),
 
 
 class TestSampleReview(TestCommon):

--- a/tests/test_pipelines/test_variant_calling.py
+++ b/tests/test_pipelines/test_variant_calling.py
@@ -180,6 +180,7 @@ class TestRealignTarget(TestVariantCalling):
                                  '-I tests/assets/jobs/test_dataset/gatk_var_calling/test_user_sample_id_recal.bam '
                                  '--known /path/to/known/indels',
                                  job_name='gatk_realign_target',
+                                 cpus=1,
                                  mem=32,
                                  working_dir='tests/assets/jobs/test_dataset/gatk_var_calling')
 
@@ -206,6 +207,7 @@ class TestRealign(TestVariantCalling):
                                  '-targetIntervals tests/assets/jobs/test_dataset/gatk_var_calling/test_user_sample_id.intervals '
                                  '--knownAlleles /path/to/known/indels',
                                  job_name='gatk_indel_realign',
+                                 cpus=1,
                                  mem=32,
                                  working_dir='tests/assets/jobs/test_dataset/gatk_var_calling')
 
@@ -251,8 +253,8 @@ class TestHaplotypeCaller(TestVariantCalling):
                 '--annotation ClippingRankSumTest '
                 '--annotation DepthPerSampleHC '
                 '--dbsnp /path/to/dbsnp.vcf.gz',
-                cpus=16,
                 job_name='gatk_haplotype_call',
+                cpus=16,
                 mem=64,
                 working_dir='tests/assets/jobs/test_dataset/gatk_var_calling'
             )
@@ -282,6 +284,7 @@ class TestGenotypeGVCFs(TestVariantCalling):
                 '--variant tests/assets/jobs/test_dataset/gatk_var_calling/test_user_sample_id.g.vcf.gz '
                 '-nt 16',
                 job_name='gatk_genotype_gvcfs',
+                cpus=1,
                 mem=16,
                 working_dir='tests/assets/jobs/test_dataset/gatk_var_calling'
             )
@@ -311,6 +314,7 @@ class TestSelectVariants(TestVariantCalling):
                 '-V tests/assets/jobs/test_dataset/gatk_var_calling/test_user_sample_id.vcf.gz '
                 '-selectType SNP ',
                 job_name='var_filtration',
+                cpus=1,
                 mem=16,
                 working_dir='tests/assets/jobs/test_dataset/gatk_var_calling'
             )
@@ -341,6 +345,7 @@ class TestVariantFiltration(TestVariantCalling):
                 "--filterExpression 'QD < 2.0 || FS > 60.0 || MQ < 40.0 || MQRankSum < -12.5 || ReadPosRankSum < -8.0' "
                 "--filterName 'SNP_FILTER'",
                 job_name='var_filtration',
+                cpus=1,
                 mem=16,
                 working_dir='tests/assets/jobs/test_dataset/gatk_var_calling'
             )

--- a/tests/test_tool_versioning.py
+++ b/tests/test_tool_versioning.py
@@ -1,4 +1,5 @@
 import os
+import multiprocessing
 from unittest.mock import patch
 from analysis_driver.tool_versioning import Toolset
 from analysis_driver.config import Configuration
@@ -13,20 +14,23 @@ class TestToolset(TestAnalysisDriver):
     def setUp(self):
         self.toolset = Toolset()
         self.toolset.versioning_cfg = Configuration(os.path.join(self.assets_path, 'tool_versioning.yaml'))
-        self.toolset.select_type('non_human_sample_processing')
+        self.program_versions = os.path.join(self.assets_path, 'program_versions.yaml')
+        self.toolset.configure('non_human_sample_processing', 0, self.program_versions)
+
+    def tearDown(self):
+        if os.path.isfile(self.program_versions):
+            os.remove(self.program_versions)
 
     @patch('analysis_driver.tool_versioning.Toolset.check_version', new=fake_check_version)
     def test_tool_paths(self):
-        self.toolset.select_version(0)
         assert self.toolset['bwa'] == 'path/to/bwa_1.0'
         assert self.toolset['gatk'] == 'path/to/gatk_3'
         assert self.toolset['fastqc'] == 'path/to/fastqc_v0.11.5'
         assert self.toolset['samtools'] == 'path/to/samtools_1.3.1'
         assert self.toolset['qsub'] == '/bin/sh'
-        assert 'qsub' in self.toolset.unversioned_tools
         assert self.toolset.tool_versions == {'bwa': 1.0, 'fastqc': 'v0.11.5', 'gatk': 3, 'samtools': '1.3.1', 'java': 8}
 
-        self.toolset.select_version(1)
+        self.toolset.configure('non_human_sample_processing', 1, self.program_versions)
         assert self.toolset['bwa'] == 'path/to/bwa_1.1'
         assert self.toolset['gatk'] == 'path/to/gatk_4'
         assert self.toolset['fastqc'] == 'path/to/fastqc_v0.11.5'
@@ -42,7 +46,7 @@ class TestToolset(TestAnalysisDriver):
 
     @patch('analysis_driver.tool_versioning.Toolset.check_version')
     def test_tool_config_inheritance(self, mocked_check):
-        self.toolset.select_version(1)
+        self.toolset.configure('non_human_sample_processing', 1, self.program_versions)
         for t in ('bwa', 'gatk', 'samtools', 'java'):
             _ = self.toolset[t]
 
@@ -84,19 +88,28 @@ class TestToolset(TestAnalysisDriver):
         )
 
     @patch('analysis_driver.tool_versioning.Toolset.check_version', new=fake_check_version)
-    def test_report(self):
-        versions_file = os.path.join(self.assets_path, 'tool_versions.yaml')
-        if os.path.isfile(versions_file):
-            os.remove(versions_file)
-
-        self.toolset.select_version(0)
-        _ = self.toolset['fastqc']  # reference a tool - should appear in versions_file
-        self.toolset.write_to_yaml(versions_file)
-        with open(versions_file, 'r') as f:
+    def test_update_versions_file(self):
+        self.toolset.update_versions_file('fastqc', 'v0.11.5')
+        with open(self.program_versions, 'r') as f:
             assert f.read() == 'fastqc: v0.11.5\n'
 
-        _ = self.toolset['bcbio']  # unversioned, should not appear below
-        _ = self.toolset['gatk']  # should appear below along with Java
-        self.toolset.write_to_yaml(versions_file)
-        with open(versions_file, 'r') as f:
+        self.toolset.update_versions_file('gatk', 3)
+        with open(self.program_versions, 'r') as f:
+            assert f.read() == 'fastqc: v0.11.5\ngatk: 3\n'
+
+    @patch('analysis_driver.tool_versioning.Toolset.check_version', new=fake_check_version)
+    def test_multiprocessing(self):
+        def run_toolset():
+            _ = self.toolset['fastqc']  # reference a tool - should appear in versions_file
+            _ = self.toolset['bcbio']  # unversioned, should not appear below
+            _ = self.toolset['gatk']  # should appear below along with Java
+
+        procs = [multiprocessing.Process(target=run_toolset) for _ in range(3)]
+        for p in procs:
+            p.start()
+
+        for p in procs:
+            p.join()
+
+        with open(self.program_versions, 'r') as f:
             assert f.read() == 'fastqc: v0.11.5\ngatk: 3\njava: 8\n'


### PR DESCRIPTION
- Adds genome_used to MostRecentProc.start with SampleDataset - closes #373 
- Toolset now lazy-loads tools, making the report contain only the tools called in that pipeline run - closes #376 
- Makes all executor calls set `cpus` and `mem` explicitly - closes #379 
- Adds IDT barcode support - closes #380 
- Avoids uploading 'NaN' to Rest API in interop metrics - closes #381 