### PR TITLE
Ensure all files have been transferred before starting run processing

### DIFF
--- a/analysis_driver/quality_control/bcl_validation.py
+++ b/analysis_driver/quality_control/bcl_validation.py
@@ -41,9 +41,24 @@ class BCLValidator(Stage):
             self.call_bcl_check()
             time.sleep(1200)
         # Call bcl check again in case the run is finished but not all bcl files have been checked. Wait 5 minutes
-        # prior to starting to ensure files have been copied over entirely, once sequencing has been completed.
-        time.sleep(300)
+        # prior to starting if the last cycle is not complete, to ensure files have been copied over entirely
+        # after sequencing has been completed.
+        if not self.last_cycle_complete():
+            time.sleep(300)
         self.call_bcl_check()
+
+    def last_cycle_complete(self):
+        """
+        Checks whether the last completed cycle is the the value of the total number of cycles expected, which
+        would mean that all cycles are complete.
+        :return: True if complete, or False if not.
+        """
+        last_completed_cycle = interop_metrics.get_last_cycles_with_existing_bcls(self.run_dir)
+        ncycles = sum(Reads.num_cycles(r) for r in self.dataset.run_info.reads.reads)
+
+        if last_completed_cycle == ncycles:
+            return True
+        return False
 
     def get_bcls_to_check(self):
         """

--- a/analysis_driver/quality_control/bcl_validation.py
+++ b/analysis_driver/quality_control/bcl_validation.py
@@ -40,7 +40,9 @@ class BCLValidator(Stage):
         while self.dataset.is_sequencing():
             self.call_bcl_check()
             time.sleep(1200)
-        # call bcl check again in case the run is finished but not all bcl files have been checked
+        # Call bcl check again in case the run is finished but not all bcl files have been checked. Wait 20 minutes
+        # prior to starting to ensure files have been copied over entirely, once sequencing has been completed.
+        time.sleep(600)
         self.call_bcl_check()
 
     def get_bcls_to_check(self):

--- a/analysis_driver/quality_control/bcl_validation.py
+++ b/analysis_driver/quality_control/bcl_validation.py
@@ -40,9 +40,9 @@ class BCLValidator(Stage):
         while self.dataset.is_sequencing():
             self.call_bcl_check()
             time.sleep(1200)
-        # Call bcl check again in case the run is finished but not all bcl files have been checked. Wait 20 minutes
+        # Call bcl check again in case the run is finished but not all bcl files have been checked. Wait 5 minutes
         # prior to starting to ensure files have been copied over entirely, once sequencing has been completed.
-        time.sleep(600)
+        time.sleep(300)
         self.call_bcl_check()
 
     def get_bcls_to_check(self):

--- a/tests/test_quality_control/test_bcl_validation.py
+++ b/tests/test_quality_control/test_bcl_validation.py
@@ -86,3 +86,13 @@ class TestBCLValidator(TestAnalysisDriver):
             self.val.check_bcls()
             assert mocked_check_bcls.called is True
             assert mocked_check_bcls.call_count == 3
+
+    @patch('analysis_driver.quality_control.interop_metrics.get_last_cycles_with_existing_bcls')
+    def test_last_cycle_complete_true(self, mocked_cycles):
+        mocked_cycles.return_value = 3  # no completed cycles
+        assert self.val.last_cycle_complete() is True
+
+    @patch('analysis_driver.quality_control.interop_metrics.get_last_cycles_with_existing_bcls')
+    def test_last_cycle_complete_false(self, mocked_cycles):
+        mocked_cycles.return_value = 2  # no completed cycles
+        assert self.val.last_cycle_complete() is False

--- a/tests/test_quality_control/test_bcl_validation.py
+++ b/tests/test_quality_control/test_bcl_validation.py
@@ -89,10 +89,10 @@ class TestBCLValidator(TestAnalysisDriver):
 
     @patch('analysis_driver.quality_control.interop_metrics.get_last_cycles_with_existing_bcls')
     def test_last_cycle_complete_true(self, mocked_cycles):
-        mocked_cycles.return_value = 3  # no completed cycles
+        mocked_cycles.return_value = 3  # 3 completed cycles
         assert self.val.last_cycle_complete() is True
 
     @patch('analysis_driver.quality_control.interop_metrics.get_last_cycles_with_existing_bcls')
     def test_last_cycle_complete_false(self, mocked_cycles):
-        mocked_cycles.return_value = 2  # no completed cycles
+        mocked_cycles.return_value = 2  # 2 completed cycles
         assert self.val.last_cycle_complete() is False


### PR DESCRIPTION
From issue: 

In some cases, some bcl files were missing at the beginning of the Run processing due to the transfer lagging behind.
We should check that all the file are present and if they're not add another 5 mins wait.

Related to issues documented in NC163.

Closes #363 