### PR TITLE
Early Fastq-Filterer

### DIFF
--- a/analysis_driver/pipelines/demultiplexing.py
+++ b/analysis_driver/pipelines/demultiplexing.py
@@ -253,7 +253,7 @@ class WaitForRead2(DemultiplexingStage):
 class PartialRun(DemultiplexingStage):
     @property
     def fastq_intermediate_dir(self):
-        return join(self.job_dir, 'fastq_intermetiate')
+        return join(self.job_dir, 'fastq_intermediate')
 
 
 class Bcl2FastqPartialRun(PartialRun):
@@ -269,7 +269,7 @@ class Bcl2FastqPartialRun(PartialRun):
         ).join()
 
 
-class EarlyFastqFilter(DemultiplexingStage):
+class EarlyFastqFilter(PartialRun):
     def _run(self):
         cmds = []
         for lane in range(1, 9):

--- a/bin/remove_phix.py
+++ b/bin/remove_phix.py
@@ -76,7 +76,7 @@ def remove_phix(sample_id):
     cmds = []
     for fqs in fastq_pairs:
         read_name_list = fqs[0][:-len('_R1_001.fastq.gz')] + '_phix_read_name.list'
-        cmds.append(bash_commands.fastq_filterer(fqs, read_name_list))
+        cmds.append(bash_commands.fastq_filterer(fqs, rm_reads=read_name_list))
 
     filterer_status = executor.execute(
         *cmds,

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from egcg_core import rest_communication, util, exceptions
+from egcg_core import rest_communication, util
 from unittest.mock import Mock, patch
 
 from egcg_core.app_logging import logging_default
@@ -123,14 +123,6 @@ class IntegrationTest(ReportingAppIntegrationTest):
         input_dir = self.cfg[integration_section].get('input_dir')
         if input_dir:
             cfg.content[test_type]['input_dir'] = input_dir
-
-        if len(os.listdir(cfg[test_type]['input_dir'])) != 1:
-            raise exceptions.EGCGError(
-                '%s input datasets found in input dir %s - 1 required' % (
-                    len(os.listdir(cfg[test_type]['input_dir'])),
-                    cfg[test_type]['input_dir']
-                )
-            )
 
         os.makedirs(cfg['jobs_dir'])
         os.makedirs(cfg[test_type]['output_dir'])

--- a/tests/test_bash_commands.py
+++ b/tests/test_bash_commands.py
@@ -110,15 +110,21 @@ class TestBashCommands(TestAnalysisDriver):
         assert bash_commands.seqtk_fqchk(fastq_file) == expected
 
     def test_fastq_filterer(self):
-        assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'), 'RE_phix_read_name.txt') == (
+        assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz')) == (
             'run_filterer in_place RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
-            'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats '
-            'RE_phix_read_name.txt RE_R1_001.fastq_discarded RE_R2_001.fastq_discarded'
+            'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq '
+            'RE_R1_001.fastq_discarded RE_R2_001.fastq_discarded --threshold 36 --stats_file RE_fastqfilterer.stats'
         )
-        assert bash_commands.fastq_filterer(('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'), 'RE_phix_read_name.txt', trim_r1=149) == (
+        obs = bash_commands.fastq_filterer(
+            ('RE_R1_001.fastq.gz', 'RE_R2_001.fastq.gz'),
+            38, [1101, 2101, 2202], 'RE_phix_read_names.txt', 149, 148, True, True, 'different_stats_file.txt'
+        )
+
+        assert obs == (
             'run_filterer keep_originals RE_R1_001.fastq.gz RE_R2_001.fastq.gz RE_R1_001_filtered.fastq.gz '
-            'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_fastqfilterer.stats '
-            'RE_phix_read_name.txt RE_R1_001.fastq_discarded RE_R2_001.fastq_discarded --trim_r1 149'
+            'RE_R2_001_filtered.fastq.gz RE_R1_001_filtered.fastq RE_R2_001_filtered.fastq RE_R1_001.fastq_discarded '
+            'RE_R2_001.fastq_discarded --threshold 38 --stats_file different_stats_file.txt --remove_tiles '
+            '1101,2101,2202 --remove_reads RE_phix_read_names.txt --trim_r1 149 --trim_r2 148 --quiet --unsafe'
         )
 
     def test_picard_gc_bias(self):

--- a/tests/test_pipelines/test_demultiplexing.py
+++ b/tests/test_pipelines/test_demultiplexing.py
@@ -89,18 +89,21 @@ class TestFastqFilter(TestAnalysisDriver):
 
             expected_call_l2 = (
                 'run_filterer in_place L2_R1_001.fastq.gz L2_R2_001.fastq.gz L2_R1_001_filtered.fastq.gz '
-                'L2_R2_001_filtered.fastq.gz L2_R1_001_filtered.fastq L2_R2_001_filtered.fastq L2_fastqfilterer.stats '
-                'L2_phix_read_name.list L2_R1_001.fastq_discarded L2_R2_001.fastq_discarded'
+                'L2_R2_001_filtered.fastq.gz L2_R1_001_filtered.fastq L2_R2_001_filtered.fastq '
+                'L2_R1_001.fastq_discarded L2_R2_001.fastq_discarded --threshold 36 '
+                '--stats_file L2_fastqfilterer.stats --remove_reads L2_phix_read_name.list'
             )
             expected_call_l3 = (
                 'run_filterer keep_originals L3_R1_001.fastq.gz L3_R2_001.fastq.gz L3_R1_001_filtered.fastq.gz '
-                'L3_R2_001_filtered.fastq.gz L3_R1_001_filtered.fastq L3_R2_001_filtered.fastq L3_fastqfilterer.stats '
-                'L3_phix_read_name.list L3_R1_001.fastq_discarded L3_R2_001.fastq_discarded --remove_tiles 1101'
+                'L3_R2_001_filtered.fastq.gz L3_R1_001_filtered.fastq L3_R2_001_filtered.fastq '
+                'L3_R1_001.fastq_discarded L3_R2_001.fastq_discarded --threshold 36 '
+                '--stats_file L3_fastqfilterer.stats --remove_tiles 1101 --remove_reads L3_phix_read_name.list'
             )
             expected_call_l4 = (
                 'run_filterer keep_originals L4_R1_001.fastq.gz L4_R2_001.fastq.gz L4_R1_001_filtered.fastq.gz '
-                'L4_R2_001_filtered.fastq.gz L4_R1_001_filtered.fastq L4_R2_001_filtered.fastq L4_fastqfilterer.stats '
-                'L4_phix_read_name.list L4_R1_001.fastq_discarded L4_R2_001.fastq_discarded --trim_r2 147'
+                'L4_R2_001_filtered.fastq.gz L4_R1_001_filtered.fastq L4_R2_001_filtered.fastq '
+                'L4_R1_001.fastq_discarded L4_R2_001.fastq_discarded --threshold 36 '
+                '--stats_file L4_fastqfilterer.stats --remove_reads L4_phix_read_name.list --trim_r2 147'
             )
             assert expected_call_l2 == pexecute.call_args[0][1]
             assert expected_call_l3 == pexecute.call_args[0][2]


### PR DESCRIPTION
- Adds a Fastq-Filterer stage before early QC - closes #396.
- Makes fq_file_prelim_cmd more flexible - only mandatory arguments are now input/output/filtered files. Everything else is passed in as part of `$*` - defaults are handled by bash_commands.fastq_filterer