### PR TITLE
Fix bcl2fastq per lane

### DIFF
--- a/analysis_driver/dataset.py
+++ b/analysis_driver/dataset.py
@@ -294,7 +294,7 @@ class RunDataset(Dataset):
         pass
 
     def sample_sheet_file_for_lane(self, lane):
-        if lane not in self._sample_sheet_file_per_lane is None:
+        if lane not in self._sample_sheet_file_per_lane:
             self._sample_sheet_file_per_lane[lane] = os.path.join(self.input_dir, 'SampleSheet_analysis_driver_lane%s.csv' % lane)
             if not os.path.isfile(self._sample_sheet_file_per_lane[lane]):
                 self._generate_samplesheet(self._sample_sheet_file_per_lane[lane], lane)

--- a/analysis_driver/pipelines/demultiplexing.py
+++ b/analysis_driver/pipelines/demultiplexing.py
@@ -75,7 +75,7 @@ class Bcl2Fastq(DemultiplexingStage):
         self.info('bcl2fastq mask: ' + ', '.join(('lane %s: %s' % (l, m) for l, m in zip(lanes, masks))))
 
         bcl2fastq_exit_status = executor.execute(
-            *(bash_commands.bcl2fastq_per_lane(self.input_dir, self.fastq_dir, self.dataset.sample_sheet_file,
+            *(bash_commands.bcl2fastq_per_lane(self.input_dir, self.fastq_dir, self.dataset.sample_sheet_file_for_lane,
                                                masks, lanes)),
             job_name='bcl2fastq',
             working_dir=self.job_dir,
@@ -270,7 +270,7 @@ class Bcl2FastqPartialRun(PartialRun):
 
         bcl2fastq_exit_status = executor.execute(
             *(bash_commands.bcl2fastq_per_lane(self.input_dir, self.fastq_intermediate_dir,
-                                               self.dataset.sample_sheet_file, masks, lanes)),
+                                               self.dataset.sample_sheet_file_for_lane, masks, lanes)),
             job_name='bcl2fastq_intermediate',
             working_dir=self.job_dir,
             cpus=8,

--- a/analysis_driver/pipelines/demultiplexing.py
+++ b/analysis_driver/pipelines/demultiplexing.py
@@ -89,9 +89,11 @@ class Bcl2Fastq(DemultiplexingStage):
         merge_lane_directories(self.fastq_dir, self.dataset.run_elements)
 
         # Copy the Samplesheet Runinfo.xml run_parameters.xml to the fastq dir
-        for f in ('SampleSheet_analysis_driver.csv', 'runParameters.xml',
-                  'RunInfo.xml', 'RTAConfiguration.xml'):
+        for f in ('runParameters.xml', 'RunInfo.xml', 'RTAConfiguration.xml'):
             shutil.copy2(join(self.input_dir, f), join(self.fastq_dir, f))
+        for lane in range(1, 9):
+            f = basename(self.dataset.sample_sheet_file_for_lane(lane))
+            shutil.copy2(self.dataset.sample_sheet_file_for_lane(lane), join(self.fastq_dir, f))
         if not exists(join(self.fastq_dir, 'InterOp')):
             shutil.copytree(join(self.input_dir, 'InterOp'), join(self.fastq_dir, 'InterOp'))
 

--- a/analysis_driver/pipelines/rapid.py
+++ b/analysis_driver/pipelines/rapid.py
@@ -41,7 +41,7 @@ class Dragen(RapidStage):
                 cmd.format(
                     dragen=cfg['dragen']['executable'], ref=cfg['dragen']['reference'], run_dir=self.input_dir,
                     lane=lane, out_dir=self.rapid_output_dir(lane), user_sample_id=sample['User Sample Name'],
-                    sample_sheet=self.dataset.sample_sheet_file, dbsnp=cfg['dragen']['dbsnp'],
+                    sample_sheet=self.dataset.sample_sheet_file_for_lane(lane), dbsnp=cfg['dragen']['dbsnp'],
                     tmp_dir=os.path.join(cfg['dragen']['staging'], self.dataset.name + '_' + lane)
                 )
             )

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -8,11 +8,11 @@ from analysis_driver.exceptions import AnalysisDriverError
 app_logger = log_cfg.get_logger(__name__)
 
 
-def bcl2fastq_per_lane(input_dir, fastq_dir, sample_sheet, masks, lanes):
+def bcl2fastq_per_lane(input_dir, fastq_dir, sample_sheet_func, masks, lanes):
     cmds = []
     for mask, lane in zip(masks, lanes):
         lane_fastq_dir = os.path.join(fastq_dir, 'lane_' + str(lane))
-        cmds.append(bcl2fastq(input_dir, lane_fastq_dir, sample_sheet, mask, lane))
+        cmds.append(bcl2fastq(input_dir, lane_fastq_dir, sample_sheet_func(lane), mask, lane))
     return cmds
 
 

--- a/analysis_driver/util/bash_commands.py
+++ b/analysis_driver/util/bash_commands.py
@@ -9,6 +9,7 @@ app_logger = log_cfg.get_logger(__name__)
 
 
 def bcl2fastq_per_lane(input_dir, fastq_dir, sample_sheet_func, masks, lanes):
+    # Note sample_sheet_func is the function to get the samplesheet not the samplesheet file itself
     cmds = []
     for mask, lane in zip(masks, lanes):
         lane_fastq_dir = os.path.join(fastq_dir, 'lane_' + str(lane))

--- a/integration_tests/data_for_clarity_lims.yaml
+++ b/integration_tests/data_for_clarity_lims.yaml
@@ -53,7 +53,7 @@ artifacts:
     - { name: l4, samples: [10015AT0001, 10015AT0002, 10015AT0003, 10015AT0004, 10015AT0006, 10015AT0007, 10015AT0008, 10015AT0009], container_name: FLOWCELL1, xpos: 0, ypos: 3 }
     - { name: l5, samples: [10015AT0001, 10015AT0002, 10015AT0003, 10015AT0004, 10015AT0006, 10015AT0007, 10015AT0008, 10015AT0009], container_name: FLOWCELL1, xpos: 0, ypos: 4 }
     - { name: l6, samples: [10015AT0001, 10015AT0002, 10015AT0003, 10015AT0004, 10015AT0006, 10015AT0007, 10015AT0008, 10015AT0009], container_name: FLOWCELL1, xpos: 0, ypos: 5 }
-    - { name: l7, samples: [10015AT0001, 10015AT0002, 10015AT0003, 10015AT0004, 10015AT0006, 10015AT0007, 10015AT0008, 10015AT0009], container_name: FLOWCELL1, xpos: 0, ypos: 6 }
+    - { name: l7, samples: [10015AT0001], container_name: FLOWCELL1, xpos: 0, ypos: 6 }
     - { name: l8, samples: [10015AT0001, 10015AT0002, 10015AT0003, 10015AT0004, 10015AT0006, 10015AT0007, 10015AT0008, 10015AT0009], container_name: FLOWCELL1, xpos: 0, ypos: 7 }
     - { name: npl1, samples: [non_pooling_sample_1], container_name: FLOWCELL2, xpos: 0, ypos: 0 }
     - { name: npl2, samples: [non_pooling_sample_2], container_name: FLOWCELL2, xpos: 0, ypos: 1 }

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -257,7 +257,7 @@ class IntegrationTest(ReportingAppIntegrationTest):
         )
         self.expect_equal(
             len(rest_communication.get_document('samples', where={'sample_id': '10015AT0004'})['run_elements']),
-            8,
+            7,
             '# run elements'
         )
         output_dir = os.path.join(cfg['run']['output_dir'], self.run_id)

--- a/tests/test_bash_commands.py
+++ b/tests/test_bash_commands.py
@@ -17,7 +17,7 @@ class TestBashCommands(TestAnalysisDriver):
 
     def test_bcl2fastq_per_lane(self):
         obs = bash_commands.bcl2fastq_per_lane(
-            self.assets_path, self.fastq_path, 'samplesheet.csv', masks=['101y8i101y'], lanes=[1]
+            self.assets_path, self.fastq_path, lambda a: 'samplesheet.csv', masks=['101y8i101y'], lanes=[1]
         )
         exp = [
             'path/to/bcl2fastq_1.0.4 -l INFO --runfolder-dir %s --output-dir %s/lane_1 -r 8 -p 8 -w 8 '

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -363,19 +363,19 @@ class TestRunDataset(TestDataset):
             self.dataset._generate_samplesheet('a_samplesheet')
             mocked_open.return_value.__enter__.return_value.write.assert_called_with('\n'.join(exp))
 
-    def test_sample_sheet_file(self):
+    def test_sample_sheet_file_for_lane(self):
         self.dataset.input_dir = os.path.join(self.assets_path)
-        sample_sheet_file = os.path.join(self.dataset.input_dir, 'SampleSheet_analysis_driver.csv')
+        sample_sheet_file = os.path.join(self.dataset.input_dir, 'SampleSheet_analysis_driver_lane1.csv')
         with patch.object(RunDataset, '_generate_samplesheet') as mgenerate:
-            _ = self.dataset.sample_sheet_file
-        mgenerate.assert_called_once_with(sample_sheet_file)
+            _ = self.dataset.sample_sheet_file_for_lane(1)
+        mgenerate.assert_called_once_with(sample_sheet_file, 1)
 
     def test_sample_sheet_file_exists(self):
         self.dataset.input_dir = os.path.join(self.assets_path)
-        sample_sheet_file = os.path.join(self.dataset.input_dir, 'SampleSheet_analysis_driver.csv')
+        sample_sheet_file = os.path.join(self.dataset.input_dir, 'SampleSheet_analysis_driver_lane1.csv')
         open(sample_sheet_file, 'w').close()
         with patch.object(RunDataset, '_generate_samplesheet') as mgenerate:
-            _ = self.dataset.sample_sheet_file
+            _ = self.dataset.sample_sheet_file_for_lane(1)
         assert mgenerate.call_count == 0
         os.remove(sample_sheet_file)
 

--- a/tests/test_pipelines/test_rapid.py
+++ b/tests/test_pipelines/test_rapid.py
@@ -22,7 +22,7 @@ class TestDragen(TestAnalysisDriver):
                 real_name='a_run',
                 type='run',
                 rapid_samples_by_lane={'2': {'sample_id': 'a_sample', 'User Sample Name': 'uid_a_sample'}},
-                sample_sheet_file='path/to/SampleSheet_analysis_driver.csv'
+                sample_sheet_file_for_lane=Mock(return_value='path/to/SampleSheet_analysis_driver.csv')
             )
         )
         d._run()


### PR DESCRIPTION
bcl2fastq does not support having barcodes in  the samplesheet when demultiplexing non pooling lanes. 
This is true regardless of if the lane being demultiplexed is non-pooling.
This means that the Samplesheet needs to be generated per lane rather than one per run.
This PR changes this behaviour and also create a test in the demultiplexing integration test with a mixture of pooling and non pooling lane.


